### PR TITLE
Phase 8.5.4.1: Quick Wins - Code Quality Improvements

### DIFF
--- a/app/colors.ts
+++ b/app/colors.ts
@@ -7,7 +7,6 @@ import { getIsDark } from './composables/useTheme'
 // Returns boolean value for use in non-reactive contexts
 const getIsDarkTheme = () => {
   const value = getIsDark()
-  console.log('[colors.ts] getIsDarkTheme():', value)
   return value
 }
 

--- a/app/components/TierBadge.vue
+++ b/app/components/TierBadge.vue
@@ -31,16 +31,13 @@ const badgeClasses = computed(() => {
   return `${baseClasses} ${sizeClasses[props.size]} ${colorClasses[props.tier]}`
 })
 
-const tierLabel = computed(() => {
-  switch (props.tier) {
-    case 2:
-      return 'Pro'
-    case 1:
-      return 'Registered'
-    default:
-      return 'Free'
-  }
-})
+const tierLabels: Record<number, string> = {
+  2: 'Pro',
+  1: 'Registered',
+  0: 'Free'
+}
+
+const tierLabel = computed(() => tierLabels[props.tier] ?? 'Free')
 </script>
 
 <template>

--- a/app/components/charts/MortalityChart.vue
+++ b/app/components/charts/MortalityChart.vue
@@ -60,7 +60,6 @@ const colorMode = useColorMode()
 const lineConfig = computed(() => {
   // Pass isDark to config so text colors update with theme
   const isDark = colorMode.value === 'dark'
-  console.log('[MortalityChart] lineConfig - colorMode.value:', colorMode.value, 'isDark:', isDark)
   if (props.chartStyle !== 'line') return undefined
   return makeBarLineChartConfig(
     props.data,
@@ -123,26 +122,17 @@ const matrixChart = ref()
 const getActiveChart = () => lineChart.value || barChart.value || matrixChart.value
 
 // Watch for dark mode changes and update chart plugins
-watch(() => colorMode.value, async (newValue, oldValue) => {
-  console.log('[MortalityChart] Color mode changed:', { oldValue, newValue })
-
+watch(() => colorMode.value, async () => {
   // Wait for next tick to ensure theme state has fully updated
   await nextTick()
 
-  console.log('[MortalityChart] After nextTick, colorMode.value:', colorMode.value)
-
   // Clear QR code cache to force regeneration with new theme colors
   clearQRCodeCache()
-  console.log('[MortalityChart] QR code cache cleared')
 
   // Force chart update to re-render plugins with new theme
   const activeChart = getActiveChart()
   if (activeChart?.chart) {
-    console.log('[MortalityChart] Updating chart...')
     activeChart.chart.update()
-    console.log('[MortalityChart] Chart updated')
-  } else {
-    console.log('[MortalityChart] No active chart found!')
   }
 })
 

--- a/app/components/charts/MortalityChartControlsPrimary.vue
+++ b/app/components/charts/MortalityChartControlsPrimary.vue
@@ -35,15 +35,12 @@ const getCountryList = (
     const allInSet = ageGroups.every(ag => countryAgs.has(ag))
     const hasAsmr = country.age_groups().size > 1
 
-    console.log(`[MortalityChartControlsPrimary] ${iso3c} (${country.jurisdiction}): age_groups size=${country.age_groups().size}, hasAsmr=${hasAsmr}`)
-
     // Disable countries that don't have the data type we need
     const isDisabled = !allInSet
       || (props.isAsmrType && !hasAsmr)
       || (props.isLifeExpectancyType && !hasAsmr)
 
     const iconName = hasAsmr ? 'i-lucide-layers' : 'i-lucide-circle'
-    console.log(`[MortalityChartControlsPrimary] ${iso3c}: icon=${iconName}`)
 
     result.push({
       label: country.jurisdiction,
@@ -56,7 +53,6 @@ const getCountryList = (
       icon: iconName
     })
   }
-  console.log('[MortalityChartControlsPrimary] Full options list:', result)
   return result
 }
 

--- a/app/composables/useExplorerDataUpdate.ts
+++ b/app/composables/useExplorerDataUpdate.ts
@@ -62,8 +62,6 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
       return { datasets: [], labels: [] }
     }
 
-    console.log('[Explorer] Filtering data with countries:', config.state.countries.value, 'dateFrom:', config.state.dateFrom.value, 'dateTo:', config.state.dateTo.value)
-
     return await getFilteredChartData(
       config.state.countries.value,
       config.state.standardPopulation.value,
@@ -103,7 +101,6 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
     shouldDownloadDataset: boolean,
     shouldUpdateDataset: boolean
   ) => {
-    console.log('[Explorer] updateData called:', { shouldDownloadDataset, shouldUpdateDataset })
     isUpdating.value = true
 
     // Only show loading overlay if update takes longer than 500ms
@@ -112,14 +109,12 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
     }, 500)
 
     if (shouldDownloadDataset) {
-      console.log('[Explorer] Downloading dataset for countries:', config.state.countries.value)
       const dataset = await updateDataset(
         config.state.chartType.value,
         config.state.countries.value,
         config.helpers.isAsmrType() ? ['all'] : config.state.ageGroups.value
       )
       config.dataset.set(dataset)
-      console.log('[Explorer] Dataset downloaded, keys:', Object.keys(dataset))
 
       // All Labels
       config.data.allChartLabels.value = getAllChartLabels(
@@ -129,7 +124,6 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
         config.state.countries.value,
         config.state.chartType.value
       )
-      console.log('[Explorer] All chart labels:', config.data.allChartLabels.value)
 
       if (config.state.chartType.value === 'yearly') {
         config.data.allYearlyChartLabels.value = config.data.allChartLabels.value
@@ -155,7 +149,6 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
       )[0]
       if (!key) return
 
-      console.log('[Explorer] Getting all chart data for countries:', config.state.countries.value)
       const newData = await getAllChartData(
         key,
         config.state.chartType.value,
@@ -170,23 +163,12 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
         config.state.baselineDateTo.value,
         config.helpers.getBaseKeysForType()
       )
-      console.log('[Explorer] newData from getAllChartData:', newData)
-      console.log('[Explorer] newData.data keys:', newData.data ? Object.keys(newData.data) : 'undefined')
       Object.assign(config.data.allChartData, newData)
-      console.log('[Explorer] allChartData after update:', config.data.allChartData)
-      console.log('[Explorer] allChartData.data keys:', config.data.allChartData.data ? Object.keys(config.data.allChartData.data) : 'undefined')
     }
 
     // Update filtered chart datasets
-    console.log('[Explorer] Calling updateFilteredData...')
     const filteredData = await updateFilteredData()
-    console.log('[Explorer] Filtered data:', filteredData)
-    console.log('[Explorer] filteredData.datasets.length:', filteredData.datasets?.length)
-    console.log('[Explorer] chartData.value before update:', config.data.chartData.value)
-    console.log('[Explorer] Updating chartData with new data')
     config.data.chartData.value = filteredData as MortalityChartData
-    console.log('[Explorer] chartData.value after update:', config.data.chartData.value)
-    console.log('[Explorer] chartData.value.datasets.length:', config.data.chartData.value?.datasets?.length)
 
     // Clear the loading timeout and hide overlay
     if (loadingTimeout) {
@@ -195,7 +177,6 @@ export function useExplorerDataUpdate(config: UseExplorerDataUpdateConfig) {
     }
     showLoadingOverlay.value = false
 
-    console.log('[Explorer] updateData completed, isUpdating = false')
     isUpdating.value = false
   }
 

--- a/app/lib/chart/chartColors.ts
+++ b/app/lib/chart/chartColors.ts
@@ -6,7 +6,6 @@ import { getIsDark } from '~/composables/useTheme'
 // Returns boolean value for use in non-reactive contexts
 export const getIsDarkTheme = () => {
   const value = getIsDark()
-  console.log('[chartColors.ts] getIsDarkTheme():', value)
   return value
 }
 

--- a/app/lib/chart/chartUtils.ts
+++ b/app/lib/chart/chartUtils.ts
@@ -1,6 +1,6 @@
-export const round = (num: number, decimals = 0): number => {
-  return Math.round(num * Math.pow(10, decimals)) / Math.pow(10, decimals)
-}
+import { round } from '~/utils'
+
+export { round }
 
 export const asPercentage = (
   value: number,

--- a/app/lib/chart/filtering.ts
+++ b/app/lib/chart/filtering.ts
@@ -165,13 +165,10 @@ export const getFilteredChartData = async (
   }
 }
 
-export const baselineMinRange = (baselineMethod: string) => {
-  switch (baselineMethod) {
-    case 'lin_reg':
-      return 2
-    case 'exp':
-      return 6
-    default:
-      return 1
-  }
+const baselineMinRanges: Record<string, number> = {
+  lin_reg: 2,
+  exp: 6
 }
+
+export const baselineMinRange = (baselineMethod: string) =>
+  baselineMinRanges[baselineMethod] ?? 1

--- a/app/lib/chart/labels.ts
+++ b/app/lib/chart/labels.ts
@@ -5,20 +5,21 @@
 import { baselineMethods, type ChartLabels } from '~/model'
 import { isMobile } from '~/utils'
 
+const asmrTitles: Record<string, string> = {
+  who: 'WHO Standard Population',
+  esp: 'European Standard Population',
+  usa: 'U.S. Standard Population'
+}
+
 const getASMRTitle = (countries: string[], standardPopulation: string) => {
-  const result = 'Standard Population'
-  switch (standardPopulation) {
-    case 'who':
-      return `WHO ${result}`
-    case 'esp':
-      return `European ${result}`
-    case 'usa':
-      return `U.S. ${result}`
-    case 'country':
-      return `${countries.join(',')} 2020 ${result}`
-    default:
-      throw new Error('Uncrecognized standard population key.')
+  if (standardPopulation === 'country') {
+    return `${countries.join(',')} 2020 Standard Population`
   }
+  const title = asmrTitles[standardPopulation]
+  if (!title) {
+    throw new Error('Uncrecognized standard population key.')
+  }
+  return title
 }
 
 const getMethodDescription = (baselineMethod: string) =>

--- a/app/lib/chart/qrCodePlugin.ts
+++ b/app/lib/chart/qrCodePlugin.ts
@@ -31,12 +31,9 @@ const drawQRCode = async (chart: Chart, url: string) => {
   const qrColor = isDarkMode ? '#ffffff' : '#000000'
   const cacheKey = `${url}|${qrColor}`
 
-  console.log('[QRCodePlugin] Drawing QR code:', { isDarkMode, qrColor, cacheKey })
-
   // Get or generate QR code
   let qrLogo = qrCodeCache.get(cacheKey)
   if (!qrLogo) {
-    console.log('[QRCodePlugin] Cache miss, generating new QR code')
     const qrSrc = await QRCode.toDataURL(url, {
       color: {
         dark: qrColor,
@@ -45,9 +42,6 @@ const drawQRCode = async (chart: Chart, url: string) => {
     })
     qrLogo = await newImage(qrSrc)
     qrCodeCache.set(cacheKey, qrLogo)
-    console.log('[QRCodePlugin] New QR code generated and cached')
-  } else {
-    console.log('[QRCodePlugin] Cache hit, using cached QR code')
   }
 
   const s = 60

--- a/app/lib/config/rankingConfig.ts
+++ b/app/lib/config/rankingConfig.ts
@@ -113,24 +113,25 @@ export function shouldEnableStandardPopulation(showASMR: boolean): boolean {
 /**
  * Get user-friendly explanation for why an option is disabled
  */
+const disabledReasons: Record<
+  'standardPopulation' | 'totalsOnly' | 'predictionInterval',
+  (state: RankingUIState) => string | null
+> = {
+  standardPopulation: state =>
+    state.standardPopulationDisabled
+      ? 'Standard Population is only used with ASMR'
+      : null,
+  totalsOnly: state =>
+    state.totalsOnlyDisabled ? 'Enable "Show Totals" first' : null,
+  predictionInterval: state =>
+    state.predictionIntervalDisabled
+      ? 'Prediction Interval is not available in cumulative or totals-only mode'
+      : null
+}
+
 export function getDisabledReason(
   option: 'standardPopulation' | 'totalsOnly' | 'predictionInterval',
   state: RankingUIState
 ): string | null {
-  switch (option) {
-    case 'standardPopulation':
-      return state.standardPopulationDisabled
-        ? 'Standard Population is only used with ASMR'
-        : null
-    case 'totalsOnly':
-      return state.totalsOnlyDisabled
-        ? 'Enable "Show Totals" first'
-        : null
-    case 'predictionInterval':
-      return state.predictionIntervalDisabled
-        ? 'Prediction Interval is not available in cumulative or totals-only mode'
-        : null
-    default:
-      return null
-  }
+  return disabledReasons[option]?.(state) ?? null
 }

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -8,6 +8,47 @@
 export const DEFAULT_BASELINE_YEAR = 2017
 
 /**
+ * Viewport breakpoints for responsive design
+ * Matches Tailwind CSS breakpoints
+ */
+export const BREAKPOINTS = {
+  MOBILE: 640,
+  TABLET: 768,
+  DESKTOP: 1024,
+  XL: 1280
+} as const
+
+/**
+ * Check if current viewport is mobile
+ */
+export const isMobile = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof (globalThis as any).window === 'undefined') return false
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (globalThis as any).window.innerWidth < BREAKPOINTS.MOBILE
+}
+
+/**
+ * Check if current viewport is tablet or larger
+ */
+export const isTablet = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof (globalThis as any).window === 'undefined') return false
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (globalThis as any).window.innerWidth >= BREAKPOINTS.TABLET
+}
+
+/**
+ * Check if current viewport is desktop or larger
+ */
+export const isDesktop = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof (globalThis as any).window === 'undefined') return false
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (globalThis as any).window.innerWidth >= BREAKPOINTS.DESKTOP
+}
+
+/**
  * Chart resizing configuration
  */
 export const CHART_RESIZE = {

--- a/app/lib/data/queries.ts
+++ b/app/lib/data/queries.ts
@@ -43,10 +43,6 @@ export const loadCountryMetadata = async (options?: {
   // Get dev countries filter from options
   const filterCountries = options?.filterCountries || []
 
-  if (import.meta.dev && filterCountries.length > 0) {
-    console.log('[loadCountryMetadata] Filtering to countries:', filterCountries)
-  }
-
   for (const rawObj of rawObjects) {
     const typedObj = rawObj as Record<string, unknown>
     if (!typedObj.iso3c) continue

--- a/app/lib/data/utils.ts
+++ b/app/lib/data/utils.ts
@@ -1,23 +1,15 @@
 /**
  * Get human-readable source description for data sources
  */
-export const getSourceDescription = (source: string) => {
-  switch (source) {
-    case 'un':
-      return '<a href="https://population.un.org/wpp/Download/Standard/MostUsed/" target="_blank">United Nations</a>'
-    case 'world_mortality':
-      return '<a href="https://github.com/akarlinsky/world_mortality" target="_blank">World Mortality</a>'
-    case 'mortality_org':
-      return '<a href="https://mortality.org/Data/STMF" target="_blank">Human Mortality Database (STMF)</a>'
-    case 'eurostat':
-      return '<a href="https://ec.europa.eu/eurostat/data/database?node_code=demomwk" target="_blank">Eurostat</a>'
-    case 'cdc':
-      return '<a href="https://wonder.cdc.gov/mcd.html" target="_blank">CDC</a>'
-    case 'statcan':
-      return 'Statistics Canada: <a href="https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1310070901" target="_blank">1</a> <a href="https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1310076801" target="_blank">2</a>'
-    case 'destatis':
-      return 'Statistisches Bundesamt: <a href="https://www.destatis.de/DE/Themen/Gesellschaft-Umwelt/Bevoelkerung/Sterbefaelle-Lebenserwartung/Publikationen/Downloads-Sterbefaelle/statistischer-bericht-sterbefaelle-tage-wochen-monate-aktuell-5126109.html" target="_blank">1</a> <a href="https://www.destatis.de/DE/Themen/Gesellschaft-Umwelt/Bevoelkerung/Sterbefaelle-Lebenserwartung/Publikationen/Downloads-Sterbefaelle/statistischer-bericht-sterbefaelle-tage-wochen-monate-endg-5126108.html?nn=209016" target="_blank">2</a>'
-    default:
-      return 'unknown'
-  }
+const sourceDescriptions: Record<string, string> = {
+  un: '<a href="https://population.un.org/wpp/Download/Standard/MostUsed/" target="_blank">United Nations</a>',
+  world_mortality: '<a href="https://github.com/akarlinsky/world_mortality" target="_blank">World Mortality</a>',
+  mortality_org: '<a href="https://mortality.org/Data/STMF" target="_blank">Human Mortality Database (STMF)</a>',
+  eurostat: '<a href="https://ec.europa.eu/eurostat/data/database?node_code=demomwk" target="_blank">Eurostat</a>',
+  cdc: '<a href="https://wonder.cdc.gov/mcd.html" target="_blank">CDC</a>',
+  statcan: 'Statistics Canada: <a href="https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1310070901" target="_blank">1</a> <a href="https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=1310076801" target="_blank">2</a>',
+  destatis: 'Statistisches Bundesamt: <a href="https://www.destatis.de/DE/Themen/Gesellschaft-Umwelt/Bevoelkerung/Sterbefaelle-Lebenserwartung/Publikationen/Downloads-Sterbefaelle/statistischer-bericht-sterbefaelle-tage-wochen-monate-aktuell-5126109.html" target="_blank">1</a> <a href="https://www.destatis.de/DE/Themen/Gesellschaft-Umwelt/Bevoelkerung/Sterbefaelle-Lebenserwartung/Publikationen/Downloads-Sterbefaelle/statistischer-bericht-sterbefaelle-tage-wochen-monate-endg-5126108.html?nn=209016" target="_blank">2</a>'
 }
+
+export const getSourceDescription = (source: string) =>
+  sourceDescriptions[source] ?? 'unknown'

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -291,8 +291,6 @@ const showLoadingOverlay = ref<boolean>(false)
 let loadingTimeout: ReturnType<typeof setTimeout> | null = null
 
 const dateSliderChanged = async (val: string[]) => {
-  console.log('[Explorer] dateSliderChanged called with:', val)
-
   // Update URL state - useUrlState now handles optimistic updates internally
   dateFrom.value = val[0]!
   dateTo.value = val[1]!
@@ -321,7 +319,6 @@ const updateData = async (
   shouldDownloadDataset: boolean,
   shouldUpdateDataset: boolean
 ) => {
-  console.log('[Explorer] updateData called:', { shouldDownloadDataset, shouldUpdateDataset })
   isUpdating.value = true
 
   // Only show loading overlay if update takes longer than 500ms
@@ -330,13 +327,11 @@ const updateData = async (
   }, 500)
 
   if (shouldDownloadDataset) {
-    console.log('[Explorer] Downloading dataset for countries:', countries.value)
     dataset = await updateDataset(
       chartType.value,
       countries.value,
       isAsmrType() ? ['all'] : ageGroups.value
     )
-    console.log('[Explorer] Dataset downloaded, keys:', Object.keys(dataset))
 
     // All Labels
     allChartLabels.value = getAllChartLabels(
@@ -346,7 +341,6 @@ const updateData = async (
       countries.value,
       chartType.value
     )
-    console.log('[Explorer] All chart labels:', allChartLabels.value)
 
     if (chartType.value === 'yearly') {
       allYearlyChartLabels.value = allChartLabels.value
@@ -374,7 +368,6 @@ const updateData = async (
     )[0]
     if (!key) return
 
-    console.log('[Explorer] Getting all chart data for countries:', countries.value)
     const newData = await getAllChartData(
       key,
       chartType.value,
@@ -389,25 +382,14 @@ const updateData = async (
       baselineDateTo.value,
       getBaseKeysForType()
     )
-    console.log('[Explorer] newData from getAllChartData:', newData)
-    console.log('[Explorer] newData.data keys:', newData.data ? Object.keys(newData.data) : 'undefined')
     Object.assign(allChartData, newData)
-    console.log('[Explorer] allChartData after update:', allChartData)
-    console.log('[Explorer] allChartData.data keys:', allChartData.data ? Object.keys(allChartData.data) : 'undefined')
 
     resetDates()
   }
 
   // Update filtered chart datasets
-  console.log('[Explorer] Calling updateFilteredData...')
   const filteredData = await updateFilteredData()
-  console.log('[Explorer] Filtered data:', filteredData)
-  console.log('[Explorer] filteredData.datasets.length:', filteredData.datasets?.length)
-  console.log('[Explorer] chartData.value before update:', chartData.value)
-  console.log('[Explorer] Updating chartData with new data')
   chartData.value = filteredData as MortalityChartData
-  console.log('[Explorer] chartData.value after update:', chartData.value)
-  console.log('[Explorer] chartData.value.datasets.length:', chartData.value?.datasets?.length)
 
   configureOptions()
 
@@ -418,7 +400,6 @@ const updateData = async (
   }
   showLoadingOverlay.value = false
 
-  console.log('[Explorer] updateData completed, isUpdating = false')
   isUpdating.value = false
 }
 
@@ -505,8 +486,6 @@ const updateFilteredData = async () => {
   if (!allChartData || !allChartData.labels || !allChartData.data) {
     return { datasets: [], labels: [] }
   }
-
-  console.log('[Explorer] Filtering data with countries:', countries.value, 'dateFrom:', dateFrom.value, 'dateTo:', dateTo.value)
 
   return await getFilteredChartData(
     countries.value,
@@ -622,30 +601,6 @@ const allChartData = reactive<AllChartData>({
 const chartData = ref<MortalityChartData | undefined>(undefined)
 
 const handleUpdate = async (key: string) => {
-  console.log('[Explorer] handleUpdate called with key:', key)
-  console.log('[Explorer] Current state:', {
-    countries: countries.value,
-    type: type.value,
-    chartType: chartType.value,
-    chartStyle: chartStyle.value,
-    isExcess: isExcess.value,
-    ageGroups: ageGroups.value,
-    standardPopulation: standardPopulation.value,
-    showBaseline: showBaseline.value,
-    baselineMethod: baselineMethod.value,
-    cumulative: cumulative.value,
-    showPredictionInterval: showPredictionInterval.value,
-    showLabels: showLabels.value,
-    maximize: maximize.value,
-    isLogarithmic: isLogarithmic.value,
-    showPercentage: showPercentage.value,
-    showTotal: showTotal.value,
-    dateFrom: dateFrom.value,
-    dateTo: dateTo.value,
-    baselineDateFrom: baselineDateFrom.value,
-    baselineDateTo: baselineDateTo.value
-  })
-
   if (countries.value.length) {
     const shouldDownloadDataset = ['_countries', '_type', '_chartType', '_ageGroups'].includes(key)
     const shouldUpdateDataset = [
@@ -673,22 +628,10 @@ const handleUpdate = async (key: string) => {
       '_userColors'
     ].includes(key)
 
-    console.log('[Explorer] Update triggers:', {
-      key,
-      shouldDownloadDataset,
-      shouldUpdateDataset,
-      needsFilterUpdate,
-      willCallUpdateData: shouldDownloadDataset || shouldUpdateDataset || needsFilterUpdate
-    })
-
     // Always call updateData if any trigger is true OR if it's a filter update
     if (shouldDownloadDataset || shouldUpdateDataset || needsFilterUpdate) {
       await updateData(shouldDownloadDataset, shouldUpdateDataset)
-    } else {
-      console.log('[Explorer] No update needed for key:', key)
     }
-  } else {
-    console.log('[Explorer] Skipping updateData - no countries selected')
   }
 
   if (chartData.value) {
@@ -702,12 +645,8 @@ let isCurrentlyUpdating = false
 let pendingUpdateKey: string | null = null
 
 const update = async (key: string) => {
-  console.log('[Explorer] update() called with key:', key)
-  console.trace('[Explorer] Call stack:')
-
   // If already updating, queue this update
   if (isCurrentlyUpdating) {
-    console.log('[Explorer] Already updating, queueing:', key)
     pendingUpdateKey = key
     return
   }
@@ -720,12 +659,10 @@ const update = async (key: string) => {
     if (pendingUpdateKey) {
       const nextKey = pendingUpdateKey
       pendingUpdateKey = null
-      console.log('[Explorer] Processing queued update:', nextKey)
       await handleUpdate(nextKey)
     }
   } finally {
     isCurrentlyUpdating = false
-    console.log('[Explorer] update() completed')
   }
 }
 
@@ -881,7 +818,6 @@ onMounted(async () => {
 
 // Chart action functions
 const copyChartLink = async () => {
-  console.log('[copyChartLink] Called')
   try {
     await navigator.clipboard.writeText(window.location.href)
     showToast('Link copied to clipboard!', 'success')
@@ -892,9 +828,7 @@ const copyChartLink = async () => {
 }
 
 const screenshotChart = () => {
-  console.log('[screenshotChart] Called')
   const canvas = document.querySelector('#chart') as HTMLCanvasElement
-  console.log('[screenshotChart] Canvas found:', !!canvas)
   if (!canvas) {
     showToast('Chart not found', 'error')
     return

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -179,6 +179,7 @@
 
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
+import { BREAKPOINTS } from '~/lib/constants'
 
 // Type definition for showcase images
 interface ShowcaseImage {
@@ -198,8 +199,8 @@ const getFilename = (title: string): string => {
 }
 
 // Check if mobile or desktop
-const isMobile = () => window.innerWidth < 768
-const isDesktop = () => window.innerWidth >= 1024
+const isMobile = () => window.innerWidth < BREAKPOINTS.TABLET
+const isDesktop = () => window.innerWidth >= BREAKPOINTS.DESKTOP
 
 // Reactive state for images
 const images = ref<ShowcaseImage[]>([])

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -172,19 +172,8 @@ export const numberWithCommas = (
       maximumFractionDigits: decimals
     })
 }
-export const isMobile = () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof (globalThis as any).window === 'undefined') return false
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (globalThis as any).window.innerWidth < 640
-}
-
-export const isDesktop = () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof (globalThis as any).window === 'undefined') return false
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (globalThis as any).window.innerWidth >= 1024
-}
+// Re-export viewport helpers from constants
+export { isMobile, isTablet, isDesktop, BREAKPOINTS } from './lib/constants'
 
 export const abbrev = (str: string, n = 20) => {
   if (str.length <= n - 2) return str
@@ -308,15 +297,12 @@ export const isStringArray = (
 ): value is (string | undefined)[] =>
   value.every(v => typeof v === 'string' || v === undefined)
 
+const DATA_TYPE_MAP: Record<string, string> = {
+  1: 'yearly',
+  2: 'monthly',
+  3: 'weekly'
+} as const
+
 export const getDataTypeDescription = (type: string): string => {
-  switch (type) {
-    case '1':
-      return 'yearly'
-    case '2':
-      return 'monthly'
-    case '3':
-      return 'weekly'
-    default:
-      return type
-  }
+  return DATA_TYPE_MAP[type] ?? type
 }


### PR DESCRIPTION
## Summary

Implements **Phase 8.5.4.1 (Quick Wins)** from the Phase 8.5 refactoring plan - four high-ROI code quality improvements that establish momentum for the larger refactoring effort.

## Changes

### 1. Extract Magic Number Constants (4.1.1) 🎯
**Problem:** Hardcoded viewport breakpoints (640, 768, 1024) scattered throughout codebase  
**Solution:** 
- Created `BREAKPOINTS` constant in `lib/constants.ts`
- Added `isMobile()`, `isTablet()`, `isDesktop()` helper functions
- Updated `app/utils.ts` and `app/pages/index.vue` to use constants

**Benefits:**
- Single source of truth for responsive design
- Easier to maintain and update breakpoints
- Matches Tailwind CSS conventions

**Impact:** 3 files changed, ~30 lines improved

---

### 2. Remove Debug Console.log Statements (4.1.2) 🧹
**Problem:** 67 console.log statements cluttering production console  
**Solution:** Removed all debug logging statements across 8 files

**Files cleaned:**
- `explorer.vue` (33 removed)
- `useExplorerDataUpdate.ts` (17 removed)
- `qrCodePlugin.ts` (4 removed)
- `MortalityChart.vue` (7 removed)
- `MortalityChartControlsPrimary.vue` (3 removed)
- `queries.ts`, `chartColors.ts`, `colors.ts` (1 each)

**Preserved:** All `console.error()` statements for proper error handling

**Benefits:**
- Clean production console
- Better user experience
- Professional appearance

**Impact:** 8 files changed, ~67 lines removed

---

### 3. Deduplicate round() Function (4.1.3) ♻️
**Problem:** Identical `round()` implementation in two files  
**Solution:** 
- Removed duplicate from `lib/chart/chartUtils.ts`
- Now imports and re-exports from `utils.ts`

**Benefits:**
- DRY principle
- Single source of truth
- Easier to maintain/modify

**Impact:** 2 files changed, ~5 lines removed

---

### 4. Replace Switch Statements with Object Literals (4.1.4) 📊
**Problem:** 19 switch statements identified, 6 were simple value mappings  
**Solution:** Refactored simple switches to object literal lookups

**Refactored:**
1. `utils.ts` - `getDataTypeDescription()` (type '1'/'2'/'3' → 'yearly'/'monthly'/'weekly')
2. `lib/data/utils.ts` - `getSourceDescription()` (8 data sources)
3. `lib/chart/labels.ts` - `getASMRTitle()` (4 standard populations)
4. `components/TierBadge.vue` - `tierLabel` computed (3 tier levels)
5. `lib/chart/filtering.ts` - `baselineMinRange()` (3 baseline methods)
6. `lib/config/rankingConfig.ts` - `getDisabledReason()` (3 option types)

**Correctly skipped:** 19 switches with complex logic (conditionals, computed values, fall-through cases)

**Benefits:**
- More declarative code
- Easier to extend (just add key-value pairs)
- Better type inference
- More concise

**Impact:** 6 files changed, ~50 lines reduced

---

## Overall Impact

- **Files changed:** 17
- **Lines removed:** ~80+ (console.logs + duplicates + verbose switches)
- **Lines added:** ~60 (constants + object literals + helpers)
- **Net improvement:** -20 lines, significantly cleaner code

## Testing

✅ **TypeScript:** No new type errors (7 pre-existing Stripe errors unchanged)  
✅ **Linting:** All issues resolved (auto-fixed 6 style issues)  
✅ **Build:** Passes (pre-existing Stripe import issue unrelated to changes)

## Verification

```bash
# Typecheck
npm run typecheck  # 7 errors (same as baseline)

# Lint
npm run lint:fix   # All issues resolved

# Git diff stats
git diff master --stat
```

## Next Steps

After merging this PR:
- **Phase 8.5.4.2:** High-Impact refactorings (14-20 hours)
  - Split MortalityChartControlsSecondary component
  - Refactor repetitive type definitions
- **Phase 8.5.4.3:** Long-term improvements (12-15 hours)
  - Reorganize utils.ts into domain modules
  - Other structural improvements

## Related

- Part of **Phase 8.5: Component Refactoring & Modularization**
- See `PHASE_8.5_REFACTORING.md` for full plan
- Follows successful completion of:
  - Phase 8.5.1 (PR #10) - Split large files
  - Phase 8.5.2 (PR #11) - Config object pattern
  - Phase 8.5.3 (PR #12) - ChartPeriod/DateRange models

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)