### PR TITLE
refactor: Split MortalityChartControlsSecondary into tab components (…

### DIFF
--- a/app/components/charts/controls/BaselineTab.vue
+++ b/app/components/charts/controls/BaselineTab.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import DateSlider from '../DateSlider.vue'
+import { specialColor } from '@/colors'
+import type { ChartType } from '@/model/period'
+
+// Feature access for tier-based features
+const { can } = useFeatureAccess()
+
+const props = defineProps<{
+  selectedBaselineMethod: { name: string, value: string, label: string }
+  baselineMethodsWithLabels: { name: string, value: string, label: string }[]
+  baselineMethod: string
+  baselineSliderValue: string[]
+  labels: string[]
+  chartType: string
+  isUpdating: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:selectedBaselineMethod': [value: { name: string, value: string, label: string }]
+  'baseline-slider-changed': [value: string[]]
+}>()
+
+// Period length management
+const periodLengthOptions = [
+  { label: '2 years', value: 2 },
+  { label: '3 years', value: 3 },
+  { label: '5 years', value: 5 },
+  { label: '10 years', value: 10 },
+  { label: 'Custom', value: 0 }
+]
+
+const selectedPeriodLength = ref(periodLengthOptions.find(o => o.value === 3) || periodLengthOptions[0])
+
+const baselineMinRange = (method: string) => method === 'mean' ? 0 : 2
+
+const baselineSliderChanged = (values: string[]) => emit('baseline-slider-changed', values)
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+      <label class="text-sm font-medium whitespace-nowrap">
+        Method
+      </label>
+      <UInputMenu
+        :model-value="props.selectedBaselineMethod"
+        :items="props.baselineMethodsWithLabels"
+        placeholder="Select Baseline Method"
+        :disabled="props.isUpdating"
+        size="sm"
+        class="flex-1"
+        @update:model-value="emit('update:selectedBaselineMethod', $event)"
+      />
+      <UPopover>
+        <UButton
+          icon="i-lucide-info"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          aria-label="Baseline method information"
+        />
+        <template #content>
+          <div class="p-3 space-y-2 max-w-xs">
+            <div class="text-xs text-gray-700 dark:text-gray-300">
+              <strong>Last Value:</strong> Uses the final value from baseline period<br>
+              <strong>Average:</strong> Mean of baseline period<br>
+              <strong>Median:</strong> Median of baseline period<br>
+              <strong>Linear Regression:</strong> Linear trend projection <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300">Free</span><br>
+              <strong>Exponential Smoothing (ETS):</strong> Adaptive trend and seasonality <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300">Free</span>
+            </div>
+          </div>
+        </template>
+      </UPopover>
+    </div>
+
+    <!-- Feature upgrade hint for baseline methods -->
+    <div
+      v-if="!can('ALL_BASELINES')"
+      class="px-3 py-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800"
+    >
+      <p class="text-xs text-blue-700 dark:text-blue-300">
+        <UIcon
+          name="i-heroicons-information-circle"
+          class="inline-block mr-1 size-3"
+        />
+        Register for free to unlock advanced baseline methods.
+      </p>
+    </div>
+
+    <div
+      v-if="props.selectedBaselineMethod"
+      class="px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+    >
+      <div class="flex items-center justify-between mb-3">
+        <label class="text-sm font-medium">Period</label>
+        <!-- Period Length Selection -->
+        <div
+          v-if="props.baselineMethod !== 'naive'"
+          class="flex items-center gap-2"
+        >
+          <label class="text-xs text-gray-600 dark:text-gray-400">Length:</label>
+          <UInputMenu
+            v-model="selectedPeriodLength"
+            :items="periodLengthOptions"
+            placeholder="Select period length"
+            size="xs"
+            class="w-28"
+          />
+        </div>
+      </div>
+      <div>
+        <DateSlider
+          :key="`${props.baselineMethod}-${selectedPeriodLength?.value ?? 3}`"
+          :slider-value="props.baselineSliderValue"
+          :labels="props.labels"
+          :chart-type="props.chartType as ChartType"
+          :color="specialColor()"
+          :min-range="baselineMinRange(props.baselineMethod)"
+          :single-value="props.baselineMethod === 'naive'"
+          :period-length="selectedPeriodLength?.value ?? 3"
+          :delay-emit="true"
+          @slider-changed="baselineSliderChanged"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/charts/controls/DisplayTab.vue
+++ b/app/components/charts/controls/DisplayTab.vue
@@ -1,0 +1,337 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  // Boolean switches
+  isExcess: boolean
+  showBaseline: boolean
+  showPredictionInterval: boolean
+  showLabels: boolean
+  maximize: boolean
+  isLogarithmic: boolean
+  showPercentage: boolean
+  cumulative: boolean
+  showTotal: boolean
+  showLogo: boolean
+  showQrCode: boolean
+  // Disabled states
+  isPopulationType: boolean
+  showBaselineOption: boolean
+  showPredictionIntervalOptionDisabled: boolean
+  showMaximizeOptionDisabled: boolean
+  showTotalOptionDisabled: boolean
+  // Visibility flags
+  showPredictionIntervalOption: boolean
+  showMaximizeOption: boolean
+  showLogarithmicOption: boolean
+  showPercentageOption: boolean
+  showCumulativeOption: boolean
+  showTotalOption: boolean
+  // Chart preset
+  chartPreset?: { name: string, value: string, label: string, category: string }
+  chartPresetOptions: { name: string, value: string, label: string, category: string }[]
+}>()
+
+const emit = defineEmits<{
+  'update:isExcess': [value: boolean]
+  'update:showBaseline': [value: boolean]
+  'update:showPredictionInterval': [value: boolean]
+  'update:showLabels': [value: boolean]
+  'update:maximize': [value: boolean]
+  'update:isLogarithmic': [value: boolean]
+  'update:showPercentage': [value: boolean]
+  'update:cumulative': [value: boolean]
+  'update:showTotal': [value: boolean]
+  'update:showLogo': [value: boolean]
+  'update:showQrCode': [value: boolean]
+  'update:chartPreset': [value: { name: string, value: string, label: string, category: string } | undefined]
+}>()
+
+// Computed v-models
+const isExcessModel = computed({
+  get: () => props.isExcess,
+  set: v => emit('update:isExcess', v)
+})
+
+const showBaselineModel = computed({
+  get: () => props.showBaseline,
+  set: v => emit('update:showBaseline', v)
+})
+
+const showPredictionIntervalModel = computed({
+  get: () => props.showPredictionInterval,
+  set: v => emit('update:showPredictionInterval', v)
+})
+
+const showLabelsModel = computed({
+  get: () => props.showLabels,
+  set: v => emit('update:showLabels', v)
+})
+
+const maximizeModel = computed({
+  get: () => props.maximize,
+  set: v => emit('update:maximize', v)
+})
+
+const isLogarithmicModel = computed({
+  get: () => props.isLogarithmic,
+  set: v => emit('update:isLogarithmic', v)
+})
+
+const showPercentageModel = computed({
+  get: () => props.showPercentage,
+  set: v => emit('update:showPercentage', v)
+})
+
+const cumulativeModel = computed({
+  get: () => props.cumulative,
+  set: v => emit('update:cumulative', v)
+})
+
+const showTotalModel = computed({
+  get: () => props.showTotal,
+  set: v => emit('update:showTotal', v)
+})
+
+const showLogoModel = computed({
+  get: () => props.showLogo,
+  set: v => emit('update:showLogo', v)
+})
+
+const showQrCodeModel = computed({
+  get: () => props.showQrCode,
+  set: v => emit('update:showQrCode', v)
+})
+
+const chartPresetModel = computed({
+  get: () => props.chartPreset,
+  set: v => emit('update:chartPreset', v)
+})
+</script>
+
+<template>
+  <div>
+    <div class="flex flex-wrap gap-4">
+      <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+        <label class="text-sm font-medium whitespace-nowrap">Excess</label>
+        <USwitch
+          v-model="isExcessModel"
+          :disabled="props.isPopulationType"
+        />
+        <UPopover>
+          <UButton
+            icon="i-lucide-info"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            aria-label="Excess mortality information"
+          />
+          <template #content>
+            <div class="p-3 space-y-2 max-w-xs">
+              <div class="text-xs text-gray-700 dark:text-gray-300">
+                Compares observed mortality to expected baseline. Positive values indicate more deaths than expected, negative values indicate fewer deaths.
+              </div>
+            </div>
+          </template>
+        </UPopover>
+      </div>
+
+      <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+        <label class="text-sm font-medium whitespace-nowrap">Baseline</label>
+        <USwitch
+          v-model="showBaselineModel"
+          :disabled="!props.showBaselineOption"
+        />
+        <UPopover>
+          <UButton
+            icon="i-lucide-info"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            aria-label="Baseline information"
+          />
+          <template #content>
+            <div class="p-3 space-y-2 max-w-xs">
+              <div class="text-xs text-gray-700 dark:text-gray-300">
+                Shows the expected mortality level used for comparison. Configure baseline period and method in the Baseline tab.
+              </div>
+            </div>
+          </template>
+        </UPopover>
+      </div>
+
+      <div
+        v-if="props.showPredictionIntervalOption"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="text-sm font-medium whitespace-nowrap">95% PI</label>
+        <USwitch
+          v-model="showPredictionIntervalModel"
+          :disabled="props.showPredictionIntervalOptionDisabled"
+        />
+        <UPopover>
+          <UButton
+            icon="i-lucide-info"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            aria-label="Prediction interval information"
+          />
+          <template #content>
+            <div class="p-3 space-y-2 max-w-xs">
+              <div class="text-xs text-gray-700 dark:text-gray-300">
+                95% Prediction Interval shows the range of uncertainty around expected values. Values outside this range are statistically significant.
+              </div>
+            </div>
+          </template>
+        </UPopover>
+      </div>
+
+      <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+        <label class="text-sm font-medium whitespace-nowrap">Show Labels</label>
+        <USwitch v-model="showLabelsModel" />
+      </div>
+
+      <div
+        v-if="props.showMaximizeOption"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="text-sm font-medium whitespace-nowrap">Maximize</label>
+        <USwitch
+          v-model="maximizeModel"
+          :disabled="props.showMaximizeOptionDisabled"
+        />
+      </div>
+
+      <div
+        v-if="props.showLogarithmicOption"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="text-sm font-medium whitespace-nowrap">Log Scale</label>
+        <USwitch
+          v-model="isLogarithmicModel"
+          :disabled="!props.showLogarithmicOption"
+        />
+      </div>
+
+      <div
+        v-if="props.showPercentageOption"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="text-sm font-medium whitespace-nowrap">Percentage</label>
+        <USwitch v-model="showPercentageModel" />
+      </div>
+
+      <div
+        v-if="props.showCumulativeOption"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="text-sm font-medium whitespace-nowrap">Cumulative</label>
+        <USwitch v-model="cumulativeModel" />
+      </div>
+
+      <div
+        v-if="props.showTotalOption"
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="text-sm font-medium whitespace-nowrap">Total</label>
+        <USwitch
+          v-model="showTotalModel"
+          :disabled="props.showTotalOptionDisabled"
+        />
+      </div>
+
+      <!-- Feature gate: Only Pro users can hide watermark -->
+      <FeatureGate feature="HIDE_WATERMARK">
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+          <label class="text-sm font-medium whitespace-nowrap">
+            Show Logo
+          </label>
+          <USwitch v-model="showLogoModel" />
+        </div>
+        <template #disabled>
+          <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50 opacity-50">
+            <label class="text-sm font-medium whitespace-nowrap">
+              Show Logo
+              <FeatureBadge
+                feature="HIDE_WATERMARK"
+                class="ml-2"
+              />
+            </label>
+            <USwitch
+              v-model="showLogoModel"
+              disabled
+            />
+          </div>
+        </template>
+      </FeatureGate>
+
+      <!-- Feature gate: Only Pro users can hide QR code -->
+      <FeatureGate feature="HIDE_QR">
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+          <label class="text-sm font-medium whitespace-nowrap">
+            Show QR Code
+          </label>
+          <USwitch v-model="showQrCodeModel" />
+        </div>
+        <template #disabled>
+          <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50 opacity-50">
+            <label class="text-sm font-medium whitespace-nowrap">
+              Show QR Code
+              <FeatureBadge
+                feature="HIDE_QR"
+                class="ml-2"
+              />
+            </label>
+            <USwitch
+              v-model="showQrCodeModel"
+              disabled
+            />
+          </div>
+        </template>
+      </FeatureGate>
+    </div>
+
+    <!-- Chart Options Section -->
+    <div class="mt-6 flex flex-col gap-4">
+      <!-- Feature gate: Only Pro users can customize chart size -->
+      <FeatureGate feature="CUSTOM_CHART_SIZE">
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+          <label class="text-sm font-medium whitespace-nowrap">
+            Chart Size
+            <FeatureBadge
+              feature="CUSTOM_CHART_SIZE"
+              class="ml-2"
+            />
+          </label>
+          <UInputMenu
+            v-model="chartPresetModel"
+            :items="props.chartPresetOptions"
+            placeholder="Select a size"
+            size="sm"
+            class="flex-1"
+          />
+        </div>
+        <template #disabled>
+          <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50 opacity-50">
+            <label class="text-sm font-medium whitespace-nowrap">
+              Chart Size
+              <FeatureBadge
+                feature="CUSTOM_CHART_SIZE"
+                class="ml-2"
+              />
+            </label>
+            <UInputMenu
+              v-model="chartPresetModel"
+              :items="props.chartPresetOptions"
+              placeholder="Select a size"
+              size="sm"
+              class="flex-1"
+              disabled
+            />
+          </div>
+        </template>
+      </FeatureGate>
+    </div>
+  </div>
+</template>

--- a/app/components/charts/controls/StyleTab.vue
+++ b/app/components/charts/controls/StyleTab.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import MultiColorPicker from '../MultiColorPicker.vue'
+
+const props = defineProps<{
+  selectedChartStyle: { name: string, value: string, label: string }
+  chartStylesWithLabels: { name: string, value: string, label: string }[]
+  selectedDecimals: { name: string, value: string, label: string }
+  decimalPrecisionsWithLabels: { name: string, value: string, label: string }[]
+  colors: string[]
+  isMatrixChartStyle: boolean
+  isUpdating: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:selectedChartStyle': [value: { name: string, value: string, label: string }]
+  'update:selectedDecimals': [value: { name: string, value: string, label: string }]
+  'colors-changed': [value: string[]]
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+      <label class="text-sm font-medium whitespace-nowrap">Chart Type</label>
+      <UInputMenu
+        :model-value="props.selectedChartStyle"
+        :items="props.chartStylesWithLabels"
+        placeholder="Select the chart type"
+        :disabled="props.isUpdating"
+        size="sm"
+        class="flex-1"
+        @update:model-value="emit('update:selectedChartStyle', $event)"
+      />
+    </div>
+
+    <!-- Feature gate: Only Pro users can customize number precision -->
+    <FeatureGate feature="CUSTOM_DECIMALS">
+      <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+        <label class="text-sm font-medium whitespace-nowrap">
+          Number Precision
+          <FeatureBadge
+            feature="CUSTOM_DECIMALS"
+            class="ml-2"
+          />
+        </label>
+        <UInputMenu
+          :model-value="props.selectedDecimals"
+          :items="props.decimalPrecisionsWithLabels"
+          placeholder="Select decimal precision"
+          :disabled="props.isUpdating"
+          size="sm"
+          class="flex-1"
+          @update:model-value="emit('update:selectedDecimals', $event)"
+        />
+      </div>
+      <template #disabled>
+        <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50 opacity-50">
+          <label class="text-sm font-medium whitespace-nowrap">
+            Number Precision
+            <FeatureBadge
+              feature="CUSTOM_DECIMALS"
+              class="ml-2"
+            />
+          </label>
+          <UInputMenu
+            :model-value="props.selectedDecimals"
+            :items="props.decimalPrecisionsWithLabels"
+            placeholder="Select decimal precision"
+            size="sm"
+            class="flex-1"
+            disabled
+          />
+        </div>
+      </template>
+    </FeatureGate>
+
+    <!-- Feature gate: Only registered users can customize colors -->
+    <FeatureGate feature="CUSTOM_COLORS">
+      <div
+        v-if="!props.isMatrixChartStyle"
+        class="px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+      >
+        <label class="block mb-2 text-sm font-medium">
+          Colors
+          <FeatureBadge
+            feature="CUSTOM_COLORS"
+            class="ml-2"
+          />
+        </label>
+        <div class="overflow-x-auto">
+          <MultiColorPicker
+            :colors="props.colors || []"
+            @colors-changed="(val) => emit('colors-changed', val)"
+          />
+        </div>
+      </div>
+      <template #disabled="{ message }">
+        <div
+          v-if="!props.isMatrixChartStyle"
+          class="px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50 opacity-50"
+        >
+          <label class="block mb-2 text-sm font-medium">
+            Colors
+            <FeatureBadge
+              feature="CUSTOM_COLORS"
+              class="ml-2"
+            />
+          </label>
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            {{ message }}
+          </p>
+        </div>
+      </template>
+    </FeatureGate>
+  </div>
+</template>


### PR DESCRIPTION
…Phase 8.5.4.2.2)

Split 745-line monolithic component into focused, reusable tab components.

Changes:
- Created DisplayTab.vue (337 lines) - Display options and chart settings
- Created BaselineTab.vue (129 lines) - Baseline method and period configuration
- Created StyleTab.vue (116 lines) - Chart style and color customization
- DataTab.vue already existed (117 lines) - Data type and aggregation options
- Reduced MortalityChartControlsSecondary.vue from 745 to 389 lines (-48%)

Component Structure:
```
components/charts/
├── MortalityChartControlsSecondary.vue (389 lines) - Tab container & orchestration
└── controls/
    ├── DataTab.vue (117 lines) - Metric, chart type, standard population
    ├── DisplayTab.vue (337 lines) - Excess, baseline, PI, labels, chart size
    ├── BaselineTab.vue (129 lines) - Baseline method, period selection
    └── StyleTab.vue (116 lines) - Chart style, decimals, colors
```

Benefits:
✅ Better separation of concerns - Each tab is self-contained ✅ Improved testability - Can test tabs in isolation ✅ Better reusability - Tab components can be used independently ✅ Easier maintenance - Smaller files, clearer responsibilities ✅ Reduced complexity - 389-line container vs 745-line monolith

Metrics:
- Files changed: 4 (1 modified, 3 new)
- MortalityChartControlsSecondary: 745 → 389 lines (-48%)
- Average tab size: ~175 lines (down from 745)
- All 514 tests passing
- TypeScript & ESLint: 0 errors

Part of Phase 8.5.4.2: High-Impact Refactorings
See PHASE_8.5_REFACTORING.md section 4.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)