### PR TITLE
feat(phase-9.4): Data-driven configuration with auto-correction

### DIFF
--- a/app/composables/useDataAvailability.ts
+++ b/app/composables/useDataAvailability.ts
@@ -1,0 +1,139 @@
+/**
+ * Data Availability Composable
+ *
+ * Provides reactive data availability checks based on metadata.
+ * Auto-corrects invalid selections when data becomes unavailable.
+ *
+ * Usage:
+ *   const state = useExplorerState()
+ *   const availability = useDataAvailability(state)
+ *
+ *   // Use availability.availableChartTypes, availableAgeGroups, etc.
+ */
+
+import { computed, onMounted, ref, watch } from 'vue'
+import { metadataService } from '@/services/metadataService'
+import { showToast } from '@/toast'
+import type { useExplorerState } from './useExplorerState'
+
+export function useDataAvailability(
+  state: ReturnType<typeof useExplorerState>
+) {
+  const isLoading = ref(true)
+  const error = ref<Error | null>(null)
+
+  // Load metadata on mount
+  onMounted(async () => {
+    try {
+      await metadataService.load()
+    } catch (e) {
+      error.value = e as Error
+      showToast('Failed to load data availability metadata', 'error')
+      console.error('[useDataAvailability] Failed to load metadata:', e)
+    } finally {
+      isLoading.value = false
+    }
+  })
+
+  // Computed: Available chart types for selected countries
+  const availableChartTypes = computed(() => {
+    if (isLoading.value || !state.countries.value.length) return []
+    try {
+      return metadataService.getAvailableChartTypes(state.countries.value)
+    } catch (e) {
+      console.error('[useDataAvailability] Error getting available chart types:', e)
+      return []
+    }
+  })
+
+  // Computed: Available age groups for selected countries + chart type
+  const availableAgeGroups = computed(() => {
+    if (isLoading.value || !state.countries.value.length) return []
+    try {
+      return metadataService.getAvailableAgeGroups(
+        state.countries.value,
+        state.chartType.value
+      )
+    } catch (e) {
+      console.error('[useDataAvailability] Error getting available age groups:', e)
+      return []
+    }
+  })
+
+  // Computed: Available date range for current selection
+  const availableDateRange = computed(() => {
+    if (isLoading.value || !state.countries.value.length) return null
+    try {
+      return metadataService.getAvailableDateRange(
+        state.countries.value,
+        state.chartType.value,
+        state.ageGroups.value
+      )
+    } catch (e) {
+      console.error('[useDataAvailability] Error getting available date range:', e)
+      return null
+    }
+  })
+
+  // Auto-correct: Chart type not available
+  watch([availableChartTypes, () => state.chartType.value], ([available, current]) => {
+    if (isLoading.value) return
+    if (available.length > 0 && !available.includes(current)) {
+      const newType = available[0]
+      if (newType) {
+        state.chartType.value = newType
+        showToast(
+          `Chart type changed to ${newType} (only type available for selected countries)`,
+          'warning'
+        )
+      }
+    }
+  })
+
+  // Auto-correct: Age groups not available
+  watch([availableAgeGroups, () => state.ageGroups.value], ([available, current]) => {
+    if (isLoading.value) return
+    if (available.length === 0) return
+
+    const invalidGroups = current.filter((g: string) => !available.includes(g))
+    if (invalidGroups.length > 0) {
+      const validGroups = current.filter((g: string) => available.includes(g))
+      const fallback = available[0]
+      state.ageGroups.value = validGroups.length > 0 ? validGroups : (fallback ? [fallback] : ['all'])
+
+      showToast('Some age groups not available for selected countries', 'warning')
+    }
+  })
+
+  // Auto-correct: Dates outside available range
+  watch(
+    [availableDateRange, () => state.dateFrom.value, () => state.dateTo.value],
+    ([range, from, to]) => {
+      if (isLoading.value) return
+      if (!range) return
+
+      let changed = false
+      if (from < range.minDate) {
+        state.dateFrom.value = range.minDate
+        changed = true
+      }
+      if (to > range.maxDate) {
+        state.dateTo.value = range.maxDate
+        changed = true
+      }
+      if (changed) {
+        showToast('Date range adjusted to available data', 'info')
+      }
+    }
+  )
+
+  return {
+    isLoading,
+    error,
+    availableChartTypes,
+    availableAgeGroups,
+    availableDateRange,
+    isAvailable: (country: string, chartType: string, ageGroup: string) =>
+      metadataService.isAvailable(country, chartType, ageGroup)
+  }
+}

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -8,6 +8,7 @@ import {
 import { useChartResize } from '@/composables/useChartResize'
 import { useExplorerHelpers } from '@/composables/useExplorerHelpers'
 import { useExplorerState } from '@/composables/useExplorerState'
+import { useDataAvailability } from '@/composables/useDataAvailability'
 import { useExplorerDataOrchestration } from '@/composables/useExplorerDataOrchestration'
 import type {
   Country
@@ -35,6 +36,9 @@ import { showToast } from '@/toast'
 
 // Phase 9.2: Centralized state management with validation
 const state = useExplorerState()
+
+// Phase 9.4: Data availability checks with auto-correction
+const _availability = useDataAvailability(state)
 
 // Router
 const _router = useRouter()


### PR DESCRIPTION
## Summary

Implements Phase 9.4 of the refactoring effort: data-driven UI configuration based on actual mortality data availability from `world_meta.csv`.

This prevents users from selecting invalid combinations that would produce empty charts by automatically correcting selections based on what data is actually available.

## Changes

### New Files

**`app/services/metadataService.ts`**
- Singleton service that loads and queries `world_meta.csv` metadata
- Provides methods to check data availability:
  - `getAvailableChartTypes()` - Chart types available for selected countries
  - `getAvailableAgeGroups()` - Age groups available for selection
  - `getAvailableDateRange()` - Min/max dates for current selection
  - `isAvailable()` - Check if specific combination is valid
- Uses intersection logic (data must be available for ALL selected countries)
- Maps data types: 1=yearly, 2=monthly, 3=weekly

**`app/composables/useDataAvailability.ts`**
- Reactive composable providing data availability checks
- Auto-correction watchers that fix invalid selections:
  - ✅ Changes chart type when unavailable
  - ✅ Filters out unavailable age groups
  - ✅ Clamps dates to available range
  - ✅ Shows user-friendly toast notifications
- Loads metadata on component mount
- Provides reactive computed properties for available options

### Modified Files

**`app/pages/explorer.vue`**
- Integrated `useDataAvailability(state)` composable
- Auto-correction now runs in background when users change selections

## Benefits

- 🚫 **Prevents empty charts** from invalid data combinations
- ✨ **Better UX** with automatic corrections and notifications
- 🔒 **Type-safe** with full TypeScript support
- ⚡ **Performant**: metadata loaded once and cached in memory
- 🎯 **Smart intersection logic** for multi-country selections

## Example Scenarios

**Before:**
- User selects Aruba (yearly data only) + weekly chart type → Empty chart
- User selects USA + age group 0-9 + yearly data → Empty chart (yearly has "all" only)

**After:**
- User selects Aruba → Weekly chart auto-changes to "yearly" with toast notification
- User selects USA + age groups → Auto-filters to show only "all" for yearly data
- Date slider automatically clamps to available date range

## Testing

- ✅ TypeScript typecheck passes
- ✅ ESLint passes  
- ✅ Production build succeeds
- ✅ All routes prerender successfully

## Related

- Part of Phase 9 refactoring series
- Builds on Phase 9.1 (validation schemas)
- Builds on Phase 9.2 (explorer decomposition)
- Builds on Phase 9.3 (state simplification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)