### PR TITLE
refactor: Phase 5b - Extract ranking.vue components

### DIFF
--- a/app/components/ranking/RankingActions.vue
+++ b/app/components/ranking/RankingActions.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+/**
+ * RankingActions Component
+ *
+ * Displays action buttons for the ranking page (Explorer link, Save ranking).
+ * Extracted from ranking.vue as part of Phase 5b refactoring.
+ */
+
+interface Props {
+  explorerLink: string
+}
+
+interface Emits {
+  (e: 'save'): void
+}
+
+defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const handleSave = () => {
+  emit('save')
+}
+</script>
+
+<template>
+  <div class="flex gap-2 mt-4">
+    <UButton
+      :to="explorerLink"
+      variant="outline"
+      size="lg"
+      class="flex-1"
+    >
+      Show in Explorer
+    </UButton>
+    <UButton
+      icon="i-lucide-save"
+      size="lg"
+      @click="handleSave"
+    >
+      Save Ranking
+    </UButton>
+  </div>
+</template>

--- a/app/components/ranking/RankingHeader.vue
+++ b/app/components/ranking/RankingHeader.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+/**
+ * RankingHeader Component
+ *
+ * Displays the page title and description for the ranking page.
+ * Extracted from ranking.vue as part of Phase 5b refactoring.
+ */
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 text-center mx-auto">
+    <h1 class="text-4xl font-bold mb-6">
+      Excess Mortality Ranking
+    </h1>
+
+    <div class="space-y-4">
+      <p class="text-lg text-gray-700 dark:text-gray-300 leading-relaxed">
+        Compare excess mortality across all available countries and regions.
+        Countries are ranked by total excess mortality for the selected period.
+      </p>
+      <p class="text-lg text-gray-600 dark:text-gray-400 leading-relaxed mb-6">
+        Click on a country name to jump directly to the
+        <NuxtLink
+          to="/explorer"
+          class="text-primary hover:underline"
+        >Explorer</NuxtLink>
+        for detailed time-series analysis and visualization.
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/components/ranking/RankingSaveModal.vue
+++ b/app/components/ranking/RankingSaveModal.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+/**
+ * RankingSaveModal Component
+ *
+ * Modal dialog for saving ranking configurations.
+ * Extracted from ranking.vue as part of Phase 5b refactoring.
+ */
+
+interface Props {
+  modelValue: boolean
+  savingChart: boolean
+  saveChartName: string
+  saveChartDescription: string
+  saveChartPublic: boolean
+  saveError: string
+  saveSuccess: boolean
+}
+
+interface Emits {
+  (e: 'update:modelValue' | 'update:saveChartPublic', value: boolean): void
+  (e: 'update:saveChartName' | 'update:saveChartDescription', value: string): void
+  (e: 'save'): void
+}
+
+defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const handleSave = () => {
+  emit('save')
+}
+
+const handleClose = () => {
+  emit('update:modelValue', false)
+}
+</script>
+
+<template>
+  <UModal
+    :model-value="modelValue"
+    title="Save Ranking"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <div class="p-4 space-y-4">
+      <!-- Name Input -->
+      <UFormGroup
+        label="Ranking Name"
+        required
+      >
+        <UInput
+          :model-value="saveChartName"
+          placeholder="Enter a name for your ranking"
+          @update:model-value="emit('update:saveChartName', $event)"
+        />
+      </UFormGroup>
+
+      <!-- Description Input -->
+      <UFormGroup label="Description (optional)">
+        <UTextarea
+          :model-value="saveChartDescription"
+          placeholder="Add a description (optional)"
+          :rows="3"
+          @update:model-value="emit('update:saveChartDescription', $event)"
+        />
+      </UFormGroup>
+
+      <!-- Public Toggle -->
+      <UFormGroup>
+        <div class="flex items-center gap-3">
+          <UToggle
+            :model-value="saveChartPublic"
+            @update:model-value="emit('update:saveChartPublic', $event)"
+          />
+          <div>
+            <div class="font-medium text-sm">
+              Make this ranking public
+            </div>
+            <div class="text-xs text-gray-500 dark:text-gray-400">
+              Public rankings appear in the chart gallery
+            </div>
+          </div>
+        </div>
+      </UFormGroup>
+
+      <!-- Error Message -->
+      <UAlert
+        v-if="saveError"
+        color="error"
+        variant="subtle"
+        :title="saveError"
+      />
+
+      <!-- Success Message -->
+      <UAlert
+        v-if="saveSuccess"
+        color="success"
+        variant="subtle"
+        title="Ranking saved successfully!"
+      />
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <UButton
+          color="neutral"
+          variant="ghost"
+          label="Cancel"
+          @click="handleClose"
+        />
+        <UButton
+          color="primary"
+          label="Save Ranking"
+          :loading="savingChart"
+          :disabled="!saveChartName.trim()"
+          @click="handleSave"
+        />
+      </div>
+    </template>
+  </UModal>
+</template>


### PR DESCRIPTION
## Summary

Phase 5b of the refactoring plan: Extract UI components from `ranking.vue` to reduce page size and improve maintainability.

### Components Created

1. **RankingHeader.vue** (~30 lines)
   - Page title and description
   - Introductory text with Explorer link

2. **RankingActions.vue** (~40 lines)
   - Action buttons: "Show in Explorer" and "Save Ranking"
   - Emits save event to parent
   - Receives explorer link as prop

3. **RankingSaveModal.vue** (~110 lines)
   - Complete modal dialog for saving rankings
   - Form inputs: name, description, public toggle
   - Error and success message handling
   - Emit-based state management

### Impact

- **ranking.vue**: 570 → 483 lines (-87 lines, -15.3%)
- Improved separation of concerns
- Enhanced component reusability
- Better code organization
- Maintained 100% functional equivalence

### Testing

✅ All unit tests passing (639 tests)
✅ All E2E tests passing (48 tests)  
✅ TypeScript type checking passed
✅ ESLint checks passed

### Changes

- Extracted static header content to `RankingHeader.vue`
- Extracted action buttons to `RankingActions.vue`
- Extracted save modal UI to `RankingSaveModal.vue`
- Updated `ranking.vue` to use new components with proper props and events
- Maintained all existing functionality and behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)