### PR TITLE
fix: Prevent ResizeObserver TypeError on explorer page

### DIFF
--- a/app/components/explorer/ExplorerChartContainer.vue
+++ b/app/components/explorer/ExplorerChartContainer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import MortalityChart from '@/components/charts/MortalityChart.vue'
 import type { ChartStyle, MortalityChartData } from '@/lib/chart/chartTypes'
 import { isMobile } from '@/utils'
@@ -24,8 +25,12 @@ const props = defineProps<{
   isCustomMode: boolean
 }>()
 
+// Ref to the actual DOM element for ResizeObserver
+const chartWrapperElement = ref<HTMLElement | null>(null)
+
 defineExpose({
-  // Expose container ref to parent
+  // Expose the actual DOM element to parent for ResizeObserver
+  chartWrapperElement
 })
 </script>
 
@@ -36,6 +41,7 @@ defineExpose({
     :ui="{ body: 'p-0' }"
   >
     <div
+      ref="chartWrapperElement"
       class="chart-wrapper relative"
       :class="{ 'resizable': !isMobile(), 'auto-mode': !props.hasBeenResized, 'custom-mode': props.isCustomMode }"
     >


### PR DESCRIPTION
## Summary
Fixes Bug 4: ResizeObserver TypeError on /explorer page

**Root Cause:** 
The `useChartResize` composable was attempting to pass a Vue component instance directly to `ResizeObserver.observe()`, which requires a DOM Element. The template ref `chartContainer` pointed to `ExplorerChartContainer.vue` component, not the actual DOM element that needed observation.

**Solution:**
1. Added `getTargetElement()` helper function to safely resolve DOM elements from both component instances and direct refs
2. Modified `ExplorerChartContainer.vue` to expose the actual `chartWrapperElement` DOM element via `defineExpose()`
3. Added proper validation to ensure element is `instanceof Element` before calling `observe()`
4. Improved type safety by avoiding `any` types and using proper TypeScript interfaces

## Changes
- **app/composables/useChartResize.ts** (+48/-18 lines)
  - Added `getTargetElement()` helper to resolve DOM elements from component refs
  - Updated `applyPresetSize()` to use helper function
  - Updated `setupResizeObserver()` with proper element validation
  - Replaced console warnings with silent returns for unready elements
  
- **app/components/explorer/ExplorerChartContainer.vue** (+8/-0 lines)
  - Added ref to `chartWrapperElement` (the div.chart-wrapper)
  - Exposed element via `defineExpose()` for parent access

## Testing
✅ TypeScript type checking passed  
✅ ESLint linting passed  
✅ 3/4 explorer E2E tests passed (1 pre-existing failure confirmed in master)  
✅ Chart resizing functionality preserved  

## Validation
- [x] No console errors on /explorer page load
- [x] ResizeObserver TypeError eliminated
- [x] Chart preset sizing works correctly
- [x] Manual drag resizing still functional
- [x] Type safety maintained (no `as any` casts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)