### PR TITLE
feat: Add legal pages (terms, privacy, refund)

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -14,6 +14,27 @@
         >
           Support us
         </ULink>
+        <span class="mx-1">·</span>
+        <ULink
+          to="/legal/terms"
+          class="text-muted hover:text-default"
+        >
+          Terms
+        </ULink>
+        <span class="mx-1">·</span>
+        <ULink
+          to="/legal/privacy"
+          class="text-muted hover:text-default"
+        >
+          Privacy
+        </ULink>
+        <span class="mx-1">·</span>
+        <ULink
+          to="/legal/refund"
+          class="text-muted hover:text-default"
+        >
+          Refund
+        </ULink>
       </p>
     </template>
 

--- a/app/pages/legal/privacy.vue
+++ b/app/pages/legal/privacy.vue
@@ -1,0 +1,478 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-4xl font-bold mb-4 text-center">
+        Privacy Policy
+      </h1>
+      <p class="text-center text-gray-600 dark:text-gray-400 mb-8">
+        Last Updated: October 30, 2025
+      </p>
+
+      <div class="space-y-6 text-gray-700 dark:text-gray-300">
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              1. Introduction
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Mortality Watch ("we," "us," or "our") is committed to protecting your privacy. This
+              Privacy Policy explains how we collect, use, disclose, and safeguard your information
+              when you use our website and services at
+              <ULink
+                to="https://staging.mortality.watch"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                staging.mortality.watch
+              </ULink>
+              (the "Service").
+            </p>
+            <p>
+              By using the Service, you consent to the data practices described in this Privacy Policy.
+              If you do not agree with this Privacy Policy, please do not use the Service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              2. Information We Collect
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>2.1 Personal Information You Provide:</strong>
+            </p>
+            <p>
+              When you create an account or use certain features of the Service, we may collect:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Account Information:</strong> Email address, username, and password (encrypted)</li>
+              <li><strong>Profile Information:</strong> Optional profile details you choose to provide</li>
+              <li><strong>Saved Charts:</strong> Charts and visualizations you create and save to your account</li>
+              <li><strong>Payment Information:</strong> When you subscribe to Pro, payment information is collected and processed by Stripe (see Section 4)</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>2.2 Information Automatically Collected:</strong>
+            </p>
+            <p>
+              When you use the Service, we automatically collect certain information:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Usage Data:</strong> Pages visited, features used, time spent on pages, charts created</li>
+              <li><strong>Device Information:</strong> Browser type, operating system, device type, IP address</li>
+              <li><strong>Analytics Data:</strong> Aggregated usage statistics collected via Umami Analytics (see Section 4.4)</li>
+              <li><strong>Cookies:</strong> Small data files stored on your device (see Section 8)</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>2.3 Information from Third Parties:</strong>
+            </p>
+            <p>
+              We do not purchase or receive personal information about you from third-party data brokers.
+              However, if you log in using a third-party authentication service (if offered), we may
+              receive basic profile information from that service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              3. How We Use Your Information
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We use the information we collect to:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Provide the Service:</strong> Create and manage your account, save and retrieve your charts, process subscriptions</li>
+              <li><strong>Improve the Service:</strong> Analyze usage patterns, identify bugs, develop new features</li>
+              <li><strong>Communicate with You:</strong> Send account-related emails (verification, password resets), respond to support requests, send service announcements</li>
+              <li><strong>Process Payments:</strong> Handle Pro subscriptions and refunds via Stripe</li>
+              <li><strong>Security and Fraud Prevention:</strong> Protect against unauthorized access, abuse, and fraud</li>
+              <li><strong>Legal Compliance:</strong> Comply with legal obligations and enforce our Terms of Service</li>
+              <li><strong>Marketing:</strong> With your consent, send newsletters or promotional materials (you may opt out at any time)</li>
+            </ul>
+            <p class="mt-4">
+              We will not sell, rent, or share your personal information with third parties for their
+              own marketing purposes without your explicit consent.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              4. Third-Party Services
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We use the following third-party services that may collect or process your information:
+            </p>
+
+            <p class="mt-4">
+              <strong>4.1 Stripe (Payment Processing):</strong>
+            </p>
+            <p>
+              When you subscribe to Pro, your payment information (credit card details) is collected
+              and processed by
+              <ULink
+                to="https://stripe.com"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                Stripe
+              </ULink>, our payment processor. We do not store your full credit card information on
+              our servers. Stripe's privacy policy is available at
+              <ULink
+                to="https://stripe.com/privacy"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                https://stripe.com/privacy
+              </ULink>.
+            </p>
+
+            <p class="mt-4">
+              <strong>4.2 Resend (Email Delivery):</strong>
+            </p>
+            <p>
+              We use
+              <ULink
+                to="https://resend.com"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                Resend
+              </ULink>
+              to send transactional emails (account verification, password resets, subscription
+              notifications). Resend processes your email address for this purpose. Resend's privacy
+              policy is available at
+              <ULink
+                to="https://resend.com/legal/privacy-policy"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                https://resend.com/legal/privacy-policy
+              </ULink>.
+            </p>
+
+            <p class="mt-4">
+              <strong>4.3 Bugsink (Error Tracking):</strong>
+            </p>
+            <p>
+              We use
+              <ULink
+                to="https://bugsink.com"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                Bugsink
+              </ULink>
+              for error tracking and debugging. When errors occur, Bugsink may collect technical
+              information about the error, including stack traces and request details. Personal
+              information is minimized in error reports. Bugsink's privacy policy is available at
+              <ULink
+                to="https://bugsink.com/privacy"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                https://bugsink.com/privacy
+              </ULink>.
+            </p>
+
+            <p class="mt-4">
+              <strong>4.4 Umami Analytics (Usage Analytics):</strong>
+            </p>
+            <p>
+              We use
+              <ULink
+                to="https://umami.is"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                Umami Analytics
+              </ULink>, a privacy-focused analytics service that does not use cookies and does not
+              track personally identifiable information. Umami collects only aggregated, anonymized
+              usage statistics (page views, referrers, device types). Umami's privacy policy is
+              available at
+              <ULink
+                to="https://umami.is/privacy"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                https://umami.is/privacy
+              </ULink>.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              5. Data Retention
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We retain your personal information for as long as necessary to provide the Service
+              and fulfill the purposes described in this Privacy Policy, unless a longer retention
+              period is required or permitted by law.
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Account Data:</strong> Retained while your account is active. If you delete your account, we will delete your personal information within 30 days, except as required for legal or security purposes.</li>
+              <li><strong>Saved Charts:</strong> Retained while your account is active. Deleted when you delete your account or individual charts.</li>
+              <li><strong>Payment Records:</strong> Retained for tax and accounting purposes as required by law (typically 7 years).</li>
+              <li><strong>Usage Analytics:</strong> Aggregated analytics data is retained indefinitely but is anonymized and not linked to individual users.</li>
+            </ul>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              6. Your Rights (GDPR/CCPA)
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              If you are a resident of the European Union (EU), European Economic Area (EEA), or
+              California, you have certain rights regarding your personal information:
+            </p>
+
+            <p class="mt-4">
+              <strong>6.1 Rights Under GDPR (EU/EEA Residents):</strong>
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Right to Access:</strong> Request a copy of the personal information we hold about you</li>
+              <li><strong>Right to Rectification:</strong> Request correction of inaccurate or incomplete information</li>
+              <li><strong>Right to Erasure:</strong> Request deletion of your personal information ("right to be forgotten")</li>
+              <li><strong>Right to Restriction:</strong> Request that we limit how we use your information</li>
+              <li><strong>Right to Data Portability:</strong> Request a copy of your data in a structured, machine-readable format</li>
+              <li><strong>Right to Object:</strong> Object to our processing of your information</li>
+              <li><strong>Right to Withdraw Consent:</strong> Withdraw consent for processing based on consent</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>6.2 Rights Under CCPA (California Residents):</strong>
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Right to Know:</strong> Request information about the personal information we collect, use, and disclose</li>
+              <li><strong>Right to Delete:</strong> Request deletion of your personal information</li>
+              <li><strong>Right to Opt-Out:</strong> Opt out of the sale of personal information (Note: We do not sell personal information)</li>
+              <li><strong>Right to Non-Discrimination:</strong> Not be discriminated against for exercising your privacy rights</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>6.3 How to Exercise Your Rights:</strong>
+            </p>
+            <p>
+              To exercise any of these rights, please contact us at
+              <ULink
+                to="mailto:support@mortality.watch"
+                class="text-primary hover:underline"
+              >
+                support@mortality.watch
+              </ULink>. We will respond to your request within 30 days (or as required by applicable law).
+            </p>
+            <p>
+              You may also manage some of your information directly through your account settings,
+              including updating your profile and deleting saved charts.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              7. Data Security
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We implement reasonable security measures to protect your personal information from
+              unauthorized access, disclosure, alteration, or destruction. These measures include:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li>Encryption of data in transit (HTTPS/TLS)</li>
+              <li>Secure password storage using industry-standard hashing (bcrypt)</li>
+              <li>Access controls and authentication requirements</li>
+              <li>Regular security audits and vulnerability assessments</li>
+              <li>Use of trusted third-party services with strong security practices</li>
+            </ul>
+            <p class="mt-4">
+              However, no method of transmission over the internet or electronic storage is 100% secure.
+              While we strive to protect your personal information, we cannot guarantee its absolute security.
+              You are responsible for maintaining the confidentiality of your account credentials.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              8. Cookies and Tracking Technologies
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We use cookies and similar tracking technologies to enhance your experience on the Service:
+            </p>
+
+            <p class="mt-4">
+              <strong>8.1 Essential Cookies:</strong>
+            </p>
+            <p>
+              These cookies are necessary for the Service to function properly. They enable core
+              functionality such as user authentication, session management, and security features.
+              You cannot opt out of essential cookies.
+            </p>
+
+            <p class="mt-4">
+              <strong>8.2 Functional Cookies:</strong>
+            </p>
+            <p>
+              These cookies remember your preferences and settings (e.g., theme selection, saved chart
+              filters). Disabling functional cookies may limit some features of the Service.
+            </p>
+
+            <p class="mt-4">
+              <strong>8.3 Analytics Cookies:</strong>
+            </p>
+            <p>
+              We use Umami Analytics, which does not set cookies and does not track personally
+              identifiable information. Umami collects only aggregated, anonymized usage statistics.
+            </p>
+
+            <p class="mt-4">
+              <strong>8.4 Managing Cookies:</strong>
+            </p>
+            <p>
+              You can manage cookie preferences through your browser settings. Most browsers allow you
+              to block or delete cookies. However, disabling cookies may affect your ability to use
+              certain features of the Service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              9. International Data Transfers
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Your information may be transferred to and processed in countries other than your country
+              of residence. These countries may have data protection laws that are different from the
+              laws of your country.
+            </p>
+            <p>
+              If you are located in the EU/EEA, we ensure that any international data transfers comply
+              with GDPR requirements, including the use of Standard Contractual Clauses or other
+              approved transfer mechanisms.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              10. Children's Privacy
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              The Service is not directed to children under the age of 13 (or 16 in the EU/EEA). We do
+              not knowingly collect personal information from children. If you believe we have collected
+              information from a child, please contact us at
+              <ULink
+                to="mailto:support@mortality.watch"
+                class="text-primary hover:underline"
+              >
+                support@mortality.watch
+              </ULink>, and we will promptly delete such information.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              11. Changes to This Privacy Policy
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We may update this Privacy Policy from time to time to reflect changes in our practices,
+              technology, legal requirements, or other factors. We will notify you of any material
+              changes by:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li>Posting the updated Privacy Policy on this page with a new "Last Updated" date</li>
+              <li>Sending an email notification to the email address associated with your account (for material changes)</li>
+            </ul>
+            <p class="mt-4">
+              Your continued use of the Service after the effective date of any changes constitutes
+              your acceptance of the revised Privacy Policy.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              12. Contact Us
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              If you have any questions, concerns, or requests regarding this Privacy Policy or our
+              data practices, please contact us at:
+            </p>
+            <p class="font-semibold">
+              Email:
+              <ULink
+                to="mailto:support@mortality.watch"
+                class="text-primary hover:underline"
+              >
+                support@mortality.watch
+              </ULink>
+            </p>
+            <p class="mt-4">
+              If you are located in the EU/EEA and are not satisfied with our response, you have the
+              right to lodge a complaint with your local data protection authority.
+            </p>
+          </div>
+        </UCard>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Page metadata
+definePageMeta({
+  title: 'Privacy Policy'
+})
+
+// SEO metadata
+useSeoMeta({
+  title: 'Privacy Policy - Mortality Watch',
+  description: 'Privacy Policy for Mortality Watch. Learn how we collect, use, and protect your personal information in compliance with GDPR and CCPA.',
+  ogTitle: 'Privacy Policy - Mortality Watch',
+  ogDescription: 'Our commitment to protecting your privacy and personal information.',
+  ogImage: '/og-image.png',
+  twitterTitle: 'Privacy Policy - Mortality Watch',
+  twitterDescription: 'How we protect your privacy and personal information.',
+  twitterImage: '/og-image.png',
+  twitterCard: 'summary_large_image'
+})
+</script>

--- a/app/pages/legal/refund.vue
+++ b/app/pages/legal/refund.vue
@@ -1,0 +1,400 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-4xl font-bold mb-4 text-center">
+        Refund Policy
+      </h1>
+      <p class="text-center text-gray-600 dark:text-gray-400 mb-8">
+        Last Updated: October 30, 2025
+      </p>
+
+      <div class="space-y-6 text-gray-700 dark:text-gray-300">
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              1. Overview
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              At Mortality Watch, we want you to be satisfied with your Pro subscription. This Refund
+              Policy explains our refund terms for Pro subscriptions and how to request a refund if
+              you are not satisfied with the Service.
+            </p>
+            <p>
+              This Refund Policy should be read in conjunction with our
+              <ULink
+                to="/legal/terms"
+                class="text-primary hover:underline"
+              >
+                Terms of Service
+              </ULink>
+              and
+              <ULink
+                to="/legal/privacy"
+                class="text-primary hover:underline"
+              >
+                Privacy Policy
+              </ULink>.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              2. 30-Day Refund Window
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>2.1 Eligibility:</strong>
+            </p>
+            <p>
+              We offer a 30-day refund window for Pro subscriptions. If you are not satisfied with
+              your Pro subscription for any reason, you may request a full refund within 30 days of
+              your initial subscription date or renewal date.
+            </p>
+
+            <p class="mt-4">
+              <strong>2.2 Refund Calculation:</strong>
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Within 30 Days:</strong> Full refund of the subscription fee paid for the current billing period</li>
+              <li><strong>After 30 Days:</strong> No refund available (except in cases of billing errors or exceptional circumstances at our discretion)</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>2.3 Refund Scope:</strong>
+            </p>
+            <p>
+              Refunds apply only to the current billing period. If you have been subscribed for
+              multiple billing periods, we will refund only the most recent charge if it is within
+              the 30-day window. Previous billing periods are not eligible for refund.
+            </p>
+
+            <p class="mt-4 bg-blue-50 dark:bg-blue-950 border-l-4 border-blue-500 p-4">
+              <strong>Example:</strong> If you subscribe on January 1st and request a refund on
+              January 25th, you will receive a full refund. If you request a refund on February 5th,
+              you will not be eligible for a refund.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              3. How to Request a Refund
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              To request a refund, please follow these steps:
+            </p>
+
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 space-y-4">
+              <div>
+                <p class="font-semibold mb-2">
+                  Step 1: Contact Support
+                </p>
+                <p>
+                  Send an email to
+                  <ULink
+                    to="mailto:support@mortality.watch"
+                    class="text-primary hover:underline font-semibold"
+                  >
+                    support@mortality.watch
+                  </ULink>
+                  with the subject line "Refund Request".
+                </p>
+              </div>
+
+              <div>
+                <p class="font-semibold mb-2">
+                  Step 2: Include Required Information
+                </p>
+                <p>
+                  In your email, please include:
+                </p>
+                <ul class="list-disc pl-6 mt-2 space-y-1">
+                  <li>Your account email address</li>
+                  <li>Your subscription start date (if known)</li>
+                  <li>A brief reason for the refund request (optional but helpful)</li>
+                </ul>
+              </div>
+
+              <div>
+                <p class="font-semibold mb-2">
+                  Step 3: Wait for Confirmation
+                </p>
+                <p>
+                  We will review your request and respond within 2-3 business days. If your request
+                  is approved, we will process the refund immediately.
+                </p>
+              </div>
+
+              <div>
+                <p class="font-semibold mb-2">
+                  Step 4: Refund Processing
+                </p>
+                <p>
+                  Approved refunds are processed through Stripe, our payment processor. The refund
+                  will be credited to your original payment method within 5-10 business days,
+                  depending on your bank or card issuer.
+                </p>
+              </div>
+            </div>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              4. What Happens After a Refund
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>4.1 Pro Access:</strong>
+            </p>
+            <p>
+              Once a refund is approved and processed, your Pro subscription will be canceled
+              immediately. You will lose access to Pro features, including:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li>Saved chart collections</li>
+              <li>Advanced analytics and filters</li>
+              <li>Export and download capabilities</li>
+              <li>Any other Pro-exclusive features</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>4.2 Your Saved Data:</strong>
+            </p>
+            <p>
+              After a refund, your account will revert to a free account. Your basic account data
+              (email, username) will be retained, but:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Saved Charts:</strong> Charts saved during your Pro subscription will be retained but may be limited in number or functionality based on free tier limits</li>
+              <li><strong>Chart Collections:</strong> Any chart collections created as a Pro user will be inaccessible but not deleted for 30 days, in case you choose to re-subscribe</li>
+              <li><strong>Data Export:</strong> You will no longer be able to export data, but you may contact us to request a one-time export of your saved charts within 14 days of the refund</li>
+            </ul>
+
+            <p class="mt-4">
+              <strong>4.3 Re-Subscription:</strong>
+            </p>
+            <p>
+              You may re-subscribe to Pro at any time after receiving a refund. However, if you
+              request multiple refunds within a short period, we reserve the right to decline future
+              subscriptions or refund requests at our discretion.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              5. Exceptions and Special Cases
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>5.1 Billing Errors:</strong>
+            </p>
+            <p>
+              If you were charged due to a billing error (e.g., duplicate charge, incorrect amount),
+              we will issue a full refund regardless of the 30-day window. Please contact us at
+              <ULink
+                to="mailto:support@mortality.watch"
+                class="text-primary hover:underline"
+              >
+                support@mortality.watch
+              </ULink>
+              immediately if you notice a billing error.
+            </p>
+
+            <p class="mt-4">
+              <strong>5.2 Service Downtime:</strong>
+            </p>
+            <p>
+              If the Service experiences significant downtime or technical issues that prevent you
+              from using Pro features for an extended period, you may be eligible for a prorated
+              refund or credit, even outside the 30-day window. Please contact us to discuss your
+              situation.
+            </p>
+
+            <p class="mt-4">
+              <strong>5.3 Account Termination:</strong>
+            </p>
+            <p>
+              If we terminate your account for violation of our Terms of Service, you will not be
+              eligible for a refund. However, if we discontinue the Pro subscription service entirely,
+              we will provide prorated refunds to all active subscribers.
+            </p>
+
+            <p class="mt-4">
+              <strong>5.4 Charitable Donations:</strong>
+            </p>
+            <p>
+              If you made a one-time donation to Mortality Watch (as opposed to a Pro subscription),
+              donations are generally non-refundable. However, if you believe a donation was made in
+              error, please contact us to discuss your situation.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              6. Cancellation Without Refund
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              If you do not wish to receive a refund but simply want to cancel your Pro subscription,
+              you can do so at any time through your account settings:
+            </p>
+
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6">
+              <ol class="list-decimal pl-6 space-y-2">
+                <li>Log in to your account</li>
+                <li>Go to Profile → Subscription Settings</li>
+                <li>Click "Cancel Subscription"</li>
+              </ol>
+              <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                Your cancellation will take effect at the end of your current billing period. You
+                will continue to have Pro access until the end of the period you have already paid for.
+                No refund will be issued for cancellations without a refund request.
+              </p>
+            </div>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              7. Refund Processing Time
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Once a refund is approved:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li><strong>Processing by Mortality Watch:</strong> Immediate (same business day)</li>
+              <li><strong>Processing by Stripe:</strong> 5-10 business days to appear on your statement</li>
+              <li><strong>Total Time:</strong> Typically 5-10 business days from approval</li>
+            </ul>
+            <p class="mt-4">
+              If you do not see the refund on your statement after 10 business days, please check with
+              your bank or card issuer, as processing times may vary. If the issue persists, contact
+              us at
+              <ULink
+                to="mailto:support@mortality.watch"
+                class="text-primary hover:underline"
+              >
+                support@mortality.watch
+              </ULink>.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              8. Currency and Exchange Rates
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Refunds will be issued in the same currency as the original payment. If your bank or
+              card issuer applies currency conversion fees or exchange rate differences, we are not
+              responsible for any discrepancies between the original charge and the refunded amount.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              9. Changes to This Refund Policy
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We may update this Refund Policy from time to time. If we make material changes, we will
+              notify you by email or by posting a notice on the Service prior to the effective date of
+              the changes.
+            </p>
+            <p>
+              Changes to this Refund Policy will not affect refund requests submitted before the
+              effective date of the changes.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              10. Contact Information
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              If you have any questions about this Refund Policy or wish to request a refund, please
+              contact us:
+            </p>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6">
+              <p class="font-semibold mb-2">
+                Email:
+              </p>
+              <p>
+                <ULink
+                  to="mailto:support@mortality.watch"
+                  class="text-primary hover:underline text-lg font-semibold"
+                >
+                  support@mortality.watch
+                </ULink>
+              </p>
+              <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                Please use the subject line "Refund Request" for fastest processing.
+              </p>
+            </div>
+          </div>
+        </UCard>
+
+        <div class="mt-8 p-6 bg-green-50 dark:bg-green-950 border-l-4 border-green-500 rounded-lg">
+          <h3 class="font-semibold text-lg mb-2">
+            Our Commitment to You
+          </h3>
+          <p>
+            We are committed to providing a valuable and reliable service. If you encounter any issues
+            with your Pro subscription or the Service, please reach out to us before requesting a refund.
+            We may be able to resolve your concerns and ensure you get the most value from Mortality Watch.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Page metadata
+definePageMeta({
+  title: 'Refund Policy'
+})
+
+// SEO metadata
+useSeoMeta({
+  title: 'Refund Policy - Mortality Watch',
+  description: 'Refund Policy for Mortality Watch Pro subscriptions. Learn about our 30-day refund window and how to request a refund.',
+  ogTitle: 'Refund Policy - Mortality Watch',
+  ogDescription: 'Our 30-day refund policy for Pro subscriptions and how to request a refund.',
+  ogImage: '/og-image.png',
+  twitterTitle: 'Refund Policy - Mortality Watch',
+  twitterDescription: '30-day refund policy for Pro subscriptions.',
+  twitterImage: '/og-image.png',
+  twitterCard: 'summary_large_image'
+})
+</script>

--- a/app/pages/legal/terms.vue
+++ b/app/pages/legal/terms.vue
@@ -1,0 +1,407 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-4xl font-bold mb-4 text-center">
+        Terms of Service
+      </h1>
+      <p class="text-center text-gray-600 dark:text-gray-400 mb-8">
+        Last Updated: October 30, 2025
+      </p>
+
+      <div class="space-y-6 text-gray-700 dark:text-gray-300">
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              1. Acceptance of Terms
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Welcome to Mortality Watch. By accessing or using our website and services at
+              <ULink
+                to="https://staging.mortality.watch"
+                target="_blank"
+                class="text-primary hover:underline"
+              >
+                staging.mortality.watch
+              </ULink>
+              (the "Service"), you agree to be bound by these Terms of Service ("Terms").
+              If you do not agree to these Terms, please do not use the Service.
+            </p>
+            <p>
+              Mortality Watch ("we," "us," or "our") provides a data visualization platform for
+              analyzing global mortality statistics. These Terms govern your use of the Service,
+              whether as a free user or as a subscriber to our Pro plan.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              2. Description of Service
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Mortality Watch is a web-based platform that provides:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li>Interactive mortality data visualizations and charts</li>
+              <li>Access to global mortality statistics from official sources</li>
+              <li>Tools for exploring and analyzing mortality trends</li>
+              <li>Data export capabilities and chart saving features</li>
+              <li>Premium features for Pro subscribers (chart collections, advanced analytics, etc.)</li>
+            </ul>
+            <p>
+              We reserve the right to modify, suspend, or discontinue any aspect of the Service
+              at any time, with or without notice. We will not be liable to you or any third party
+              for any modification, suspension, or discontinuation of the Service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              3. User Accounts
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>3.1 Account Creation:</strong> To access certain features of the Service,
+              including saving charts and subscribing to Pro, you must create an account. You agree
+              to provide accurate, current, and complete information during registration and to update
+              such information to keep it accurate, current, and complete.
+            </p>
+            <p>
+              <strong>3.2 Account Security:</strong> You are responsible for maintaining the
+              confidentiality of your account credentials and for all activities that occur under
+              your account. You agree to notify us immediately of any unauthorized use of your account.
+            </p>
+            <p>
+              <strong>3.3 Account Termination:</strong> We reserve the right to suspend or terminate
+              your account at any time for any reason, including if we believe you have violated these
+              Terms. You may terminate your account at any time through your profile settings.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              4. Pro Subscription Terms
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>4.1 Subscription Plans:</strong> Mortality Watch offers a Pro subscription
+              plan that provides access to premium features. Subscription pricing and features are
+              described on our Features page.
+            </p>
+            <p>
+              <strong>4.2 Payment:</strong> By subscribing to Pro, you agree to pay all applicable
+              subscription fees. We use Stripe for payment processing. Your payment information is
+              processed securely by Stripe and is not stored on our servers.
+            </p>
+            <p>
+              <strong>4.3 Billing Cycle:</strong> Pro subscriptions are billed on a recurring basis
+              (monthly or annual, depending on your selected plan). You will be charged automatically
+              at the beginning of each billing cycle unless you cancel your subscription.
+            </p>
+            <p>
+              <strong>4.4 Cancellation:</strong> You may cancel your Pro subscription at any time
+              through your profile settings. Cancellation will take effect at the end of your current
+              billing period. No refunds will be issued for partial billing periods, except as described
+              in our Refund Policy.
+            </p>
+            <p>
+              <strong>4.5 Price Changes:</strong> We reserve the right to change subscription pricing.
+              We will provide at least 30 days' notice of any price increases. If you do not agree to
+              the new pricing, you may cancel your subscription.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              5. User Conduct
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              You agree not to:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li>Use the Service for any illegal purpose or in violation of any laws</li>
+              <li>Attempt to gain unauthorized access to the Service or its related systems</li>
+              <li>Interfere with or disrupt the Service or servers or networks connected to the Service</li>
+              <li>Use any automated means (bots, scrapers, etc.) to access the Service without our written permission</li>
+              <li>Reproduce, duplicate, copy, sell, or resell any portion of the Service without our written permission</li>
+              <li>Upload or transmit viruses, malware, or any other malicious code</li>
+              <li>Impersonate any person or entity or falsely state or misrepresent your affiliation with any person or entity</li>
+              <li>Collect or harvest any personally identifiable information from the Service</li>
+              <li>Use the Service to spam, harass, or harm others</li>
+            </ul>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              6. Intellectual Property
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>6.1 Our Property:</strong> The Service and its original content (excluding user
+              data and open-source components), features, and functionality are owned by Mortality Watch
+              and are protected by international copyright, trademark, patent, trade secret, and other
+              intellectual property laws.
+            </p>
+            <p>
+              <strong>6.2 Open Source:</strong> Mortality Watch's codebase is open source and available
+              under the licenses specified in our GitHub repositories. The use of our open-source code
+              is governed by those respective licenses.
+            </p>
+            <p>
+              <strong>6.3 Mortality Data:</strong> The mortality data provided through the Service is
+              aggregated from official government sources and international organizations. Such data is
+              typically in the public domain or available under open data licenses. We do not claim
+              ownership of the underlying mortality statistics.
+            </p>
+            <p>
+              <strong>6.4 Your Content:</strong> You retain ownership of any charts, analyses, or other
+              content you create using the Service. By using the Service, you grant us a limited,
+              non-exclusive license to store and display your saved charts as necessary to provide the
+              Service to you.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              7. Data Accuracy and Disclaimer
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>7.1 No Warranty:</strong> While we strive to provide accurate and up-to-date
+              mortality data, we make no warranties or representations about the accuracy, completeness,
+              or reliability of the data or visualizations provided through the Service.
+            </p>
+            <p>
+              <strong>7.2 Not Medical or Public Health Advice:</strong> The Service is for informational
+              and educational purposes only. The data, visualizations, and analyses provided through the
+              Service should not be used as a substitute for professional medical or public health advice,
+              diagnosis, or treatment.
+            </p>
+            <p>
+              <strong>7.3 Use at Your Own Risk:</strong> You acknowledge that any reliance on data or
+              information provided through the Service is at your own risk. We are not liable for any
+              decisions or actions you take based on information from the Service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              8. Limitation of Liability
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              TO THE MAXIMUM EXTENT PERMITTED BY LAW, MORTALITY WATCH AND ITS AFFILIATES, OFFICERS,
+              EMPLOYEES, AGENTS, PARTNERS, AND LICENSORS SHALL NOT BE LIABLE FOR ANY INDIRECT,
+              INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING WITHOUT LIMITATION,
+              LOSS OF PROFITS, DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM:
+            </p>
+            <ul class="list-disc pl-6 space-y-2">
+              <li>Your access to or use of or inability to access or use the Service</li>
+              <li>Any conduct or content of any third party on the Service</li>
+              <li>Any content obtained from the Service</li>
+              <li>Unauthorized access, use, or alteration of your transmissions or content</li>
+            </ul>
+            <p>
+              IN NO EVENT SHALL OUR AGGREGATE LIABILITY FOR ALL CLAIMS RELATING TO THE SERVICE EXCEED
+              THE GREATER OF $100 USD OR THE AMOUNT YOU PAID US IN THE PAST TWELVE MONTHS FOR THE
+              SERVICE.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              9. Indemnification
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              You agree to indemnify, defend, and hold harmless Mortality Watch and its affiliates,
+              officers, directors, employees, agents, licensors, and suppliers from and against all
+              losses, expenses, damages, costs, claims, and demands, including reasonable attorneys'
+              fees, resulting from your use of the Service, your violation of these Terms, or your
+              violation of any rights of another party.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              10. Privacy
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              Your use of the Service is also governed by our
+              <ULink
+                to="/legal/privacy"
+                class="text-primary hover:underline"
+              >
+                Privacy Policy
+              </ULink>, which describes how we collect, use, and protect your personal information.
+              By using the Service, you consent to the practices described in the Privacy Policy.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              11. Third-Party Services
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              The Service may contain links to third-party websites or services (such as data sources,
+              GitHub, social media platforms, payment processors) that are not owned or controlled by
+              Mortality Watch. We have no control over and assume no responsibility for the content,
+              privacy policies, or practices of any third-party websites or services.
+            </p>
+            <p>
+              You acknowledge and agree that we shall not be responsible or liable for any damage or
+              loss caused by your use of any third-party content, goods, or services available through
+              the Service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              12. Changes to Terms
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              We reserve the right to modify these Terms at any time. If we make material changes,
+              we will notify you by email (if you have provided an email address) or by posting a
+              notice on the Service prior to the effective date of the changes.
+            </p>
+            <p>
+              Your continued use of the Service after the effective date of any changes constitutes
+              your acceptance of the revised Terms. If you do not agree to the revised Terms, you
+              must stop using the Service.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              13. Governing Law and Dispute Resolution
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>13.1 Governing Law:</strong> These Terms shall be governed by and construed in
+              accordance with the laws of the jurisdiction in which Mortality Watch operates, without
+              regard to its conflict of law provisions.
+            </p>
+            <p>
+              <strong>13.2 Dispute Resolution:</strong> Any dispute arising from these Terms or your
+              use of the Service shall be resolved through binding arbitration, except that either
+              party may seek injunctive or other equitable relief in any court of competent jurisdiction
+              to prevent infringement of intellectual property rights.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              14. General Provisions
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              <strong>14.1 Entire Agreement:</strong> These Terms, together with our Privacy Policy
+              and Refund Policy, constitute the entire agreement between you and Mortality Watch
+              regarding the Service.
+            </p>
+            <p>
+              <strong>14.2 Severability:</strong> If any provision of these Terms is found to be
+              invalid or unenforceable, the remaining provisions will remain in full force and effect.
+            </p>
+            <p>
+              <strong>14.3 Waiver:</strong> No waiver of any term of these Terms shall be deemed a
+              further or continuing waiver of such term or any other term.
+            </p>
+            <p>
+              <strong>14.4 Assignment:</strong> You may not assign or transfer these Terms or your
+              rights under these Terms without our prior written consent. We may assign these Terms
+              without restriction.
+            </p>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="text-2xl font-semibold">
+              15. Contact Information
+            </h2>
+          </template>
+          <div class="space-y-4">
+            <p>
+              If you have any questions about these Terms, please contact us at:
+            </p>
+            <p class="font-semibold">
+              Email:
+              <ULink
+                to="mailto:support@mortality.watch"
+                class="text-primary hover:underline"
+              >
+                support@mortality.watch
+              </ULink>
+            </p>
+          </div>
+        </UCard>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Page metadata
+definePageMeta({
+  title: 'Terms of Service'
+})
+
+// SEO metadata
+useSeoMeta({
+  title: 'Terms of Service - Mortality Watch',
+  description: 'Terms of Service for Mortality Watch, a data visualization platform for analyzing global mortality statistics.',
+  ogTitle: 'Terms of Service - Mortality Watch',
+  ogDescription: 'Terms governing the use of Mortality Watch services and subscription plans.',
+  ogImage: '/og-image.png',
+  twitterTitle: 'Terms of Service - Mortality Watch',
+  twitterDescription: 'Terms governing the use of Mortality Watch services.',
+  twitterImage: '/og-image.png',
+  twitterCard: 'summary_large_image'
+})
+</script>


### PR DESCRIPTION
## Overview
Adds legal pages required for GDPR/CCPA compliance and public launch.

## Changes
- ✅ Terms of Service page (/legal/terms)
- ✅ Privacy Policy page (/legal/privacy)
- ✅ Refund Policy page (/legal/refund)
- ✅ Footer links updated

## Templates Used
- Termly/TermsFeed templates customized for context
- Covers data collection, third parties, retention policies
- 30-day refund window as specified

## Testing
- ✅ TypeScript compilation successful
- ✅ All pages render correctly
- ✅ Mobile responsive
- ✅ Footer links work across all pages

## Legal Review
- [ ] Legal review recommended before merge (optional)

Resolves: Phase 6.5