### PR TITLE
fix: Correct component name for ChartCard in homepage

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -87,7 +87,7 @@
         v-else-if="featuredCharts.length > 0"
         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
       >
-        <ChartCard
+        <ChartsChartCard
           v-for="chart of featuredCharts"
           :key="chart.id"
           :chart="chart"


### PR DESCRIPTION
## Summary
- Fixed Vue warning by correcting component reference from `ChartCard` to `ChartsChartCard` in homepage

## Details
The component is located at `app/components/charts/ChartCard.vue`, so Nuxt's auto-import system requires it to be referenced as `ChartsChartCard` (with directory prefix).

Other pages (`my-charts.vue` and `charts.vue`) were already using the correct naming convention.

## Changes
- `app/pages/index.vue`: Changed `<ChartCard>` to `<ChartsChartCard>`

## Testing
- [x] Dev server runs without Vue warnings
- [x] Homepage renders correctly
- [x] Featured charts display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)