### PR TITLE
fix: capitalize chart type labels in gallery (#117)

### DIFF
--- a/app/components/charts/ChartCard.vue
+++ b/app/components/charts/ChartCard.vue
@@ -101,7 +101,7 @@
         variant="subtle"
         size="xs"
       >
-        {{ chart.chartType }}
+        {{ chart.chartType === 'explorer' ? 'Explorer' : 'Ranking' }}
       </UBadge>
     </div>
 

--- a/app/pages/admin/featured-charts.vue
+++ b/app/pages/admin/featured-charts.vue
@@ -177,7 +177,7 @@
                 variant="subtle"
                 size="xs"
               >
-                {{ chart.chartType }}
+                {{ chart.chartType === 'explorer' ? 'Explorer' : 'Ranking' }}
               </UBadge>
             </div>
           </div>

--- a/app/pages/charts/[slug].vue
+++ b/app/pages/charts/[slug].vue
@@ -149,7 +149,7 @@
                 :color="chart.chartType === 'explorer' ? 'info' : 'success'"
                 variant="subtle"
               >
-                {{ chart.chartType }}
+                {{ chart.chartType === 'explorer' ? 'Explorer' : 'Ranking' }}
               </UBadge>
             </dd>
           </div>


### PR DESCRIPTION
Fixed inconsistent capitalization of chart type labels by changing:
- 'explorer' → 'Explorer'
- 'ranking' → 'Ranking'

Updated three files where chart types are displayed as badges.

Generated with [Claude Code](https://claude.com/claude-code)