### PR TITLE
feat: gate Show Caption feature for premium users (#115)

### DIFF
--- a/app/components/charts/controls/DisplayTab.vue
+++ b/app/components/charts/controls/DisplayTab.vue
@@ -262,10 +262,34 @@ const chartPresetModel = computed({
             <USwitch v-model="showLabelsModel" />
           </div>
 
-          <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-            <label class="text-sm font-medium whitespace-nowrap">Show Caption</label>
-            <USwitch v-model="showCaptionModel" />
-          </div>
+          <!-- Feature gate: Only Pro users can show caption -->
+          <FeatureGate feature="SHOW_CAPTION">
+            <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+              <label class="text-sm font-medium whitespace-nowrap">
+                Show Caption
+                <FeatureBadge
+                  feature="SHOW_CAPTION"
+                  class="ml-2"
+                />
+              </label>
+              <USwitch v-model="showCaptionModel" />
+            </div>
+            <template #disabled>
+              <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50 opacity-50">
+                <label class="text-sm font-medium whitespace-nowrap">
+                  Show Caption
+                  <FeatureBadge
+                    feature="SHOW_CAPTION"
+                    class="ml-2"
+                  />
+                </label>
+                <USwitch
+                  v-model="showCaptionModel"
+                  disabled
+                />
+              </div>
+            </template>
+          </FeatureGate>
 
           <div
             v-if="props.showMaximizeOption"

--- a/app/config/features.config.ts
+++ b/app/config/features.config.ts
@@ -167,6 +167,13 @@ export const FEATURES = {
     category: 'branding'
   },
 
+  SHOW_CAPTION: {
+    tier: TIERS.PRO,
+    name: 'Show Caption',
+    description: 'Display chart caption with metadata',
+    category: 'branding'
+  },
+
   ADVANCED_LE: {
     tier: TIERS.PRO,
     name: 'Advanced Life Expectancy',


### PR DESCRIPTION
This commit implements premium gating for the "Show Caption" feature, restricting it to Pro-tier users only.

Changes:
- Added SHOW_CAPTION feature to features.config.ts (TIER 2 - PRO)
- Wrapped Show Caption control in DisplayTab.vue with FeatureGate component
- Added FeatureBadge to indicate premium status
- Non-premium users see disabled control with upgrade prompt

Implementation follows existing premium feature patterns used for HIDE_WATERMARK and HIDE_QR features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)