### PR TITLE
fix: handle ASMR errors properly in ranking page (#146)

### DIFF
--- a/app/composables/useRankingData.test.ts
+++ b/app/composables/useRankingData.test.ts
@@ -301,15 +301,30 @@ describe('useRankingData', () => {
       )
     })
 
-    it('should handle null response', async () => {
+    it('should handle null response with ASMR error message when ASMR is enabled', async () => {
       const ranking = useRankingData(mockState, mockMetaData, ref('2020'))
 
+      mockState.showASMR.value = true
       mockDataFetcher.fetchChartData.mockResolvedValue(null)
 
       await ranking.loadData()
 
       expect(showToast).toHaveBeenCalledWith(
         'No ASMR data for selected countries. Please select CMR',
+        'warning'
+      )
+    })
+
+    it('should handle null response with CMR error message when CMR is enabled', async () => {
+      const ranking = useRankingData(mockState, mockMetaData, ref('2020'))
+
+      mockState.showASMR.value = false
+      mockDataFetcher.fetchChartData.mockResolvedValue(null)
+
+      await ranking.loadData()
+
+      expect(showToast).toHaveBeenCalledWith(
+        'No data available for selected countries',
         'warning'
       )
     })

--- a/app/composables/useRankingData.ts
+++ b/app/composables/useRankingData.ts
@@ -251,7 +251,10 @@ export function useRankingData(
     })
 
     if (!result) {
-      showToast('No ASMR data for selected countries. Please select CMR', 'warning')
+      const errorMessage = type === 'asmr'
+        ? 'No ASMR data for selected countries. Please select CMR'
+        : 'No data available for selected countries'
+      showToast(errorMessage, 'warning')
       return null
     }
 


### PR DESCRIPTION
## Summary
- Fixed error messaging on ranking page to be context-aware based on active mode
- CMR mode now shows "No data available for selected countries" instead of ASMR-specific errors
- Added test coverage for CMR mode error handling

## Test Plan
- ✅ npm run check passes (all 1487 unit tests pass)
- ✅ Error messages are context-appropriate for CMR and ASMR modes
- ⚠️ e2e tests have pre-existing failures unrelated to this change

## Changes Made
- Modified `useRankingData.ts` line 254-257 to check mode before displaying error message
- Added test for CMR mode error handling in `useRankingData.test.ts`
- When ASMR mode: Shows "No ASMR data for selected countries. Please select CMR"
- When CMR mode: Shows "No data available for selected countries"

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)