### PR TITLE
fix: support cumulative+percentage mode with excess

### DIFF
--- a/app/lib/chart/strategies/DataTransformationPipeline.test.ts
+++ b/app/lib/chart/strategies/DataTransformationPipeline.test.ts
@@ -224,8 +224,8 @@ describe('DataTransformationPipeline', () => {
         key1_lower: [8, 18, 28],
         key1_upper: [12, 22, 32],
         key1_baseline: [5, 10, 15],
-        key1_lower_baseline: [4, 9, 14],
-        key1_upper_baseline: [6, 11, 16]
+        key1_baseline_lower: [4, 9, 14],
+        key1_baseline_upper: [6, 11, 16]
       }
       const config = {
         showPercentage: true,
@@ -239,14 +239,11 @@ describe('DataTransformationPipeline', () => {
 
       expect(result).toHaveLength(3)
       // [10, 20, 30] / [5, 10, 15] = [2, 2, 2]
-      // [8, 18, 28] / [5, 10, 15] = [1.6, 1.8, 1.867]
-      // [12, 22, 32] / [5, 10, 15] = [2.4, 2.2, 2.133]
-      expect(result[0]).toMatchObject({ x: 0, y: 2, yMin: 1.6, yMax: 2.4 })
-      expect(result[1]).toMatchObject({ x: 1, y: 2, yMin: 1.8, yMax: 2.2 })
-      expect(result[2]?.x).toBe(2)
-      expect(result[2]?.y).toBe(2)
-      expect(result[2]?.yMin).toBeCloseTo(1.867, 2)
-      expect(result[2]?.yMax).toBeCloseTo(2.133, 2)
+      // [8, 18, 28] / [4, 9, 14] = [2, 2, 2]
+      // [12, 22, 32] / [6, 11, 16] = [2, 2, 2]
+      expect(result[0]).toMatchObject({ x: 0, y: 2, yMin: 2, yMax: 2 })
+      expect(result[1]).toMatchObject({ x: 1, y: 2, yMin: 2, yMax: 2 })
+      expect(result[2]).toMatchObject({ x: 2, y: 2, yMin: 2, yMax: 2 })
     })
   })
 })

--- a/app/lib/chart/strategies/PercentageTransformStrategy.test.ts
+++ b/app/lib/chart/strategies/PercentageTransformStrategy.test.ts
@@ -98,5 +98,37 @@ describe('PercentageTransformStrategy', () => {
 
       expect(result).toBe('asmr_esp_baseline')
     })
+
+    it('should handle excess with lower confidence interval', () => {
+      const key = 'deaths_excess_lower'
+
+      const result = strategy.getBaselineKey(false, key)
+
+      expect(result).toBe('deaths_baseline_lower')
+    })
+
+    it('should handle excess with upper confidence interval', () => {
+      const key = 'deaths_excess_upper'
+
+      const result = strategy.getBaselineKey(false, key)
+
+      expect(result).toBe('deaths_baseline_upper')
+    })
+
+    it('should handle ASMR excess with lower confidence interval', () => {
+      const key = 'asmr_who_excess_lower'
+
+      const result = strategy.getBaselineKey(true, key)
+
+      expect(result).toBe('asmr_who_baseline_lower')
+    })
+
+    it('should handle ASMR excess with upper confidence interval', () => {
+      const key = 'asmr_who_excess_upper'
+
+      const result = strategy.getBaselineKey(true, key)
+
+      expect(result).toBe('asmr_who_baseline_upper')
+    })
   })
 })

--- a/app/lib/chart/strategies/PercentageTransformStrategy.ts
+++ b/app/lib/chart/strategies/PercentageTransformStrategy.ts
@@ -27,10 +27,21 @@ export class PercentageTransformStrategy {
    * @returns The baseline key
    */
   getBaselineKey(isAsmr: boolean, key: string): string {
+    // Handle confidence interval suffixes (_lower, _upper)
+    const ciSuffix = key.endsWith('_lower') ? '_lower' : key.endsWith('_upper') ? '_upper' : ''
+    const keyWithoutCi = ciSuffix ? key.slice(0, -ciSuffix.length) : key
+
+    // Remove _excess suffix if present
+    const keyWithoutExcess = keyWithoutCi.replace(/_excess$/, '')
+
     if (isAsmr) {
-      return `${key.split('_')[0]}_${key.split('_')[1]}_baseline`
+      // ASMR format: asmr_who_excess → asmr_who_baseline
+      const parts = keyWithoutExcess.split('_')
+      return `${parts[0]}_${parts[1]}_baseline${ciSuffix}`
     } else {
-      return `${key.split('_')[0]}_baseline`
+      // Non-ASMR format: deaths_excess → deaths_baseline
+      const parts = keyWithoutExcess.split('_')
+      return `${parts[0]}_baseline${ciSuffix}`
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixed cumulative + percentage mode to work correctly with excess mode enabled
- Updated PercentageTransformStrategy baseline key resolution to handle confidence intervals
- Fixed getBaselineKey() to strip _excess suffix before resolving baseline keys while preserving confidence interval suffixes

## Technical Details
When excess mode was enabled, keys like `deaths_excess_lower` were incorrectly mapped to `deaths_baseline` instead of `deaths_baseline_lower`. The fix ensures proper baseline key resolution for confidence intervals.

## Test Plan
- ✅ npm run check passes (all 1490 unit tests)
- ✅ Added 4 new test cases for excess with confidence intervals
- ✅ Fixed incorrect test expectations in DataTransformationPipeline.test.ts

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)