### PR TITLE
fix: make reset-db.sh compatible with sh for Docker environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx scripts/seed-admin.ts",
-    "db:reset": "bash scripts/reset-db.sh",
+    "db:reset": "sh scripts/reset-db.sh",
     "prepare": "node -e \"try{require('husky')}catch{}\""
   },
   "dependencies": {

--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Helper script to reset the database
 # This is useful during development when you need a fresh start
@@ -9,13 +9,19 @@ set -e
 echo "⚠️  WARNING: This will DELETE ALL DATA in the database!"
 echo "This script is intended for development use only."
 echo ""
-read -p "Are you sure you want to continue? (yes/no): " -r
+printf "Are you sure you want to continue? (yes/no): "
+read -r REPLY
 echo ""
 
-if [[ ! $REPLY =~ ^[Yy]es$ ]]; then
-  echo "❌ Aborted."
-  exit 1
-fi
+case "$REPLY" in
+  [Yy]es)
+    # Continue with script
+    ;;
+  *)
+    echo "❌ Aborted."
+    exit 1
+    ;;
+esac
 
 # Remove the database file if it exists
 DB_PATH="./.data/mortality.db"


### PR DESCRIPTION
## Summary
Converts the database reset script from bash to POSIX-compliant sh for better portability across different environments.

## Problem
The `npm run db:reset` command was failing in Alpine Linux Docker containers with:
```
sh: bash: not found
```

Alpine Linux containers typically only have `sh` available by default, not `bash`.

## Changes
- Changed shebang from `#!/bin/bash` to `#!/bin/sh`
- Replaced bash-specific `[[` test with POSIX-compliant `case` statement
- Replaced `read -p` with `printf` + `read` for POSIX compatibility
- Updated `package.json` to use `sh` instead of `bash`

## Testing
- ✅ Tested locally with sh (accepts "yes", rejects "no")
- ✅ Script maintains same functionality
- ✅ Works in both development and Docker environments

## Impact
- Works in Alpine Linux Docker containers without installing bash
- Maintains compatibility with all environments that have sh
- No breaking changes to functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)