### PR TITLE
feat: add public/private toggle for saved charts (#134)

### DIFF
--- a/app/components/charts/ChartCard.vue
+++ b/app/components/charts/ChartCard.vue
@@ -212,6 +212,21 @@
           </template>
         </div>
 
+        <!-- Visibility Toggle (My Charts only) -->
+        <div
+          v-if="variant === 'my-charts'"
+          class="flex items-center justify-between pt-2 border-t border-gray-200 dark:border-gray-700"
+        >
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {{ chart.isPublic ? 'Public' : 'Private' }}
+          </span>
+          <USwitch
+            :model-value="chart.isPublic"
+            :loading="isTogglingVisibility"
+            @update:model-value="(value: boolean) => $emit('toggle-visibility', chart.id, value)"
+          />
+        </div>
+
         <!-- Admin: Feature Toggle -->
         <div
           v-if="showAdminToggle && (variant === 'my-charts' ? chart.isPublic : true)"
@@ -255,16 +270,19 @@ interface Props {
   variant: 'homepage' | 'gallery' | 'my-charts' | 'admin'
   showAdminToggle?: boolean
   isToggling?: boolean
+  isTogglingVisibility?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showAdminToggle: false,
-  isToggling: false
+  isToggling: false,
+  isTogglingVisibility: false
 })
 
 defineEmits<{
   'delete': [chartId: number]
   'toggle-featured': [chartId: number, value: boolean]
+  'toggle-visibility': [chartId: number, value: boolean]
 }>()
 
 // Get the public chart link (/charts/:slug)

--- a/app/pages/my-charts.vue
+++ b/app/pages/my-charts.vue
@@ -39,8 +39,10 @@
         variant="my-charts"
         :show-admin-toggle="isAdmin"
         :is-toggling="togglingFeatured === chart.id"
+        :is-toggling-visibility="togglingVisibility === chart.id"
         @delete="deleteChart"
         @toggle-featured="toggleFeatured"
+        @toggle-visibility="toggleVisibility"
       />
     </div>
 
@@ -135,6 +137,29 @@ async function deleteChart(chartId: number) {
     await refresh()
   } catch (err) {
     handleApiError(err, 'delete chart', 'deleteChart')
+  }
+}
+
+// Toggle visibility status
+const togglingVisibility = ref<number | null>(null)
+
+async function toggleVisibility(chartId: number, newValue: boolean) {
+  togglingVisibility.value = chartId
+  try {
+    await $fetch(`/api/charts/${chartId}`, {
+      method: 'PATCH',
+      body: { isPublic: newValue }
+    })
+
+    // Update local state
+    const chart = charts.value.find(c => c.id === chartId)
+    if (chart) {
+      chart.isPublic = newValue
+    }
+  } catch (err) {
+    handleApiError(err, 'update chart visibility', 'toggleVisibility')
+  } finally {
+    togglingVisibility.value = null
   }
 }
 

--- a/server/api/charts/[id].patch.ts
+++ b/server/api/charts/[id].patch.ts
@@ -1,0 +1,74 @@
+import { db } from '../../utils/db'
+import { savedCharts } from '../../../db/schema'
+import { eq } from 'drizzle-orm'
+import { ChartVisibilityUpdateResponseSchema } from '../../schemas'
+
+/**
+ * PATCH /api/charts/:id
+ *
+ * Update chart visibility (isPublic)
+ * Requires authentication and ownership (or admin)
+ */
+export default defineEventHandler(async (event) => {
+  // Require authentication
+  const user = await requireAuth(event)
+
+  const chartId = parseInt(event.context.params?.id || '')
+
+  if (isNaN(chartId)) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid chart ID'
+    })
+  }
+
+  const body = await readBody(event)
+  const { isPublic } = body
+
+  // Validation
+  if (typeof isPublic !== 'boolean') {
+    throw createError({
+      statusCode: 400,
+      message: 'isPublic must be a boolean'
+    })
+  }
+
+  try {
+    // Check ownership
+    const charts = await db
+      .select()
+      .from(savedCharts)
+      .where(eq(savedCharts.id, chartId))
+      .limit(1)
+
+    const chart = charts[0]
+
+    if (!chart) {
+      throw createError({ statusCode: 404, message: 'Chart not found' })
+    }
+
+    // Only owner or admin can update
+    if (chart.userId !== user.id && user.role !== 'admin') {
+      throw createError({ statusCode: 403, message: 'Permission denied' })
+    }
+
+    // Update chart visibility
+    const updated = await db
+      .update(savedCharts)
+      .set({ isPublic })
+      .where(eq(savedCharts.id, chartId))
+      .returning()
+
+    const response = {
+      success: true as const,
+      chart: updated[0]
+    }
+    return ChartVisibilityUpdateResponseSchema.parse(response)
+  } catch (err) {
+    logger.error('Error updating chart visibility:', err instanceof Error ? err : new Error(String(err)))
+    throw createError({
+      statusCode: 500,
+      message: 'Failed to update chart visibility'
+    })
+  }
+})

--- a/server/schemas/chart.ts
+++ b/server/schemas/chart.ts
@@ -66,6 +66,12 @@ export const ChartFeatureUpdateResponseSchema = z.object({
   chart: SavedChartSchema
 })
 
+// Chart visibility update response schema
+export const ChartVisibilityUpdateResponseSchema = z.object({
+  success: z.literal(true),
+  chart: SavedChartSchema
+})
+
 // Export types
 export type SavedChart = z.infer<typeof SavedChartSchema>
 export type SimpleChart = z.infer<typeof SimpleChartSchema>
@@ -74,3 +80,4 @@ export type ChartsListResponse = z.infer<typeof ChartsListResponseSchema>
 export type ChartGetResponse = z.infer<typeof ChartGetResponseSchema>
 export type ChartDeleteResponse = z.infer<typeof ChartDeleteResponseSchema>
 export type ChartFeatureUpdateResponse = z.infer<typeof ChartFeatureUpdateResponseSchema>
+export type ChartVisibilityUpdateResponse = z.infer<typeof ChartVisibilityUpdateResponseSchema>


### PR DESCRIPTION
Fixes #134

## Changes
- Added PATCH `/api/charts/:id` endpoint to update chart visibility
- Added visibility toggle switch in My Charts page
- Shows current visibility state with Public/Private badge
- Includes loading state during toggle operation
- Toggle only appears for chart owners in My Charts view

## Implementation Details
- **New API Endpoint**: `PATCH /api/charts/:id` accepts `isPublic` boolean parameter
- **Authorization**: Only chart owners or admins can update visibility
- **UI Component**: Toggle switch shows loading state while updating
- **Visual Feedback**: Badge displays current visibility status (Public/Private)
- **Schema Updates**: Added `ChartVisibilityUpdateResponseSchema` for type safety

## Testing
- Toggle switches between public and private states
- Changes persist correctly across page refreshes
- Loading state prevents multiple concurrent updates
- Unauthorized users cannot update chart visibility
- All unit tests pass: `npm run check` ✅
- Type checking passes: `npm run typecheck` ✅

## Files Changed
- `server/api/charts/[id].patch.ts` (new): API endpoint for visibility updates
- `server/schemas/chart.ts`: Added response schema
- `app/components/charts/ChartCard.vue`: Added visibility toggle UI
- `app/pages/my-charts.vue`: Added toggle handler and state management

**Total Changes**: 4 files changed, 125 insertions(+), 1 deletion(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)