### PR TITLE
fix: standardize Relative to Percentage terminology (#139)

### DIFF
--- a/app/components/RankingTable.vue
+++ b/app/components/RankingTable.vue
@@ -157,7 +157,7 @@ const selectedItemsPerPage = computed(() =>
                   row[label] as number
                     / (row[label] === Number.MIN_SAFE_INTEGER
                       ? 1
-                      : display.showRelative
+                      : display.showPercentage
                         ? 1
                         : label === 'TOTAL'
                           ? 1000
@@ -167,7 +167,7 @@ const selectedItemsPerPage = computed(() =>
             >
               <span v-if="row[label] !== Number.MIN_SAFE_INTEGER">
                 {{
-                  display.showRelative
+                  display.showPercentage
                     ? asPercentage(row[label] as number, decimalPlaces, '')
                     : roundToStr(row[label] as number, decimalPlaces)
                 }}
@@ -181,7 +181,7 @@ const selectedItemsPerPage = computed(() =>
                   {{
                     row[`${label}_l`] === Number.MIN_SAFE_INTEGER
                       ? ''
-                      : display.showRelative
+                      : display.showPercentage
                         ? `[${asPercentage(row[`${label}_l`] as number, decimalPlaces, '')}, ${asPercentage(row[`${label}_u`] as number, decimalPlaces, '')}]`
                         : `[${roundToStr(row[`${label}_l`] as number, decimalPlaces)}, ${roundToStr(row[`${label}_u`] as number, decimalPlaces)}]`
                   }}
@@ -196,7 +196,7 @@ const selectedItemsPerPage = computed(() =>
                   row['TOTAL'] as number
                     / (row['TOTAL'] === Number.MIN_SAFE_INTEGER
                       ? 1
-                      : display.showRelative
+                      : display.showPercentage
                         ? 1
                         : 1000)
                 )
@@ -204,7 +204,7 @@ const selectedItemsPerPage = computed(() =>
             >
               <span v-if="row['TOTAL'] !== Number.MIN_SAFE_INTEGER">
                 {{
-                  display.showRelative
+                  display.showPercentage
                     ? asPercentage(row['TOTAL'] as number, decimalPlaces, '')
                     : roundToStr(row['TOTAL'] as number, decimalPlaces)
                 }}
@@ -215,7 +215,7 @@ const selectedItemsPerPage = computed(() =>
                   {{
                     row[`TOTAL_l`] === Number.MIN_SAFE_INTEGER
                       ? ''
-                      : display.showRelative
+                      : display.showPercentage
                         ? `[${asPercentage(row[`TOTAL_l`] as number, decimalPlaces, '')}, ${asPercentage(row[`TOTAL_u`] as number, decimalPlaces, '')}]`
                         : `[${roundToStr(row[`TOTAL_l`] as number, decimalPlaces)}, ${roundToStr(row[`TOTAL_u`] as number, decimalPlaces)}]`
                   }}
@@ -261,7 +261,7 @@ const selectedItemsPerPage = computed(() =>
     </div>
 
     <div class="mt-4 text-sm text-gray-600 dark:text-gray-400">
-      {{ display.showRelative ? '' : 'per 100,000 population · ' }}{{ display.subtitle }}
+      {{ display.showPercentage ? '' : 'per 100,000 population · ' }}{{ display.subtitle }}
     </div>
   </div>
 </template>

--- a/app/components/ranking/RankingSettings.vue
+++ b/app/components/ranking/RankingSettings.vue
@@ -13,7 +13,7 @@ interface Props {
   showTotals: boolean
   showTotalsOnly: boolean
   hideIncomplete: boolean
-  showRelative: boolean
+  showPercentage: boolean
   cumulative: boolean
   showPI: boolean
   selectedBaselineMethod: { label: string, name: string, value: string }
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   'update:showTotals': [value: boolean]
   'update:showTotalsOnly': [value: boolean]
   'update:hideIncomplete': [value: boolean]
-  'update:showRelative': [value: boolean]
+  'update:showPercentage': [value: boolean]
   'update:cumulative': [value: boolean]
   'update:showPI': [value: boolean]
   'update:selectedBaselineMethod': [value: { label: string, name: string, value: string }]
@@ -69,9 +69,9 @@ const hideIncompleteLocal = computed({
   set: val => emit('update:hideIncomplete', val)
 })
 
-const showRelativeLocal = computed({
-  get: () => props.showRelative,
-  set: val => emit('update:showRelative', val)
+const showPercentageLocal = computed({
+  get: () => props.showPercentage,
+  set: val => emit('update:showPercentage', val)
 })
 
 const cumulativeLocal = computed({
@@ -205,8 +205,8 @@ const activeTab = ref('metric')
         </div>
 
         <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-          <label class="text-sm font-medium whitespace-nowrap">Relative</label>
-          <USwitch v-model="showRelativeLocal" />
+          <label class="text-sm font-medium whitespace-nowrap">Percentage</label>
+          <USwitch v-model="showPercentageLocal" />
         </div>
 
         <div class="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">

--- a/app/composables/useRankingData.test.ts
+++ b/app/composables/useRankingData.test.ts
@@ -136,7 +136,7 @@ describe('useRankingData', () => {
       cumulative: ref(false),
       dateFrom: ref('2010'),
       dateTo: ref('2024'),
-      showRelative: ref(false),
+      showPercentage: ref(false),
       showTotals: ref(false),
       showTotalsOnly: ref(false),
       hideIncomplete: ref(false)
@@ -725,7 +725,7 @@ describe('useRankingData', () => {
 
       vi.clearAllMocks()
 
-      mockState.showRelative.value = true
+      mockState.showPercentage.value = true
 
       await nextTick()
 

--- a/app/composables/useRankingData.ts
+++ b/app/composables/useRankingData.ts
@@ -318,7 +318,7 @@ export function useRankingData(
           metaData: metaData.value,
           explorerLink,
           display: {
-            showRelative: state.showRelative.value,
+            showPercentage: state.showPercentage.value,
             cumulative: state.cumulative.value,
             hideIncomplete: state.hideIncomplete.value
           },
@@ -417,7 +417,7 @@ export function useRankingData(
       () => state.dateTo.value,
       () => state.baselineDateFrom.value,
       () => state.baselineDateTo.value,
-      () => state.showRelative.value,
+      () => state.showPercentage.value,
       () => state.showTotals.value,
       () => state.showTotalsOnly.value,
       () => state.hideIncomplete.value

--- a/app/composables/useRankingState.ts
+++ b/app/composables/useRankingState.ts
@@ -76,7 +76,7 @@ export function useRankingState() {
     set: (val: boolean) => updateQuery({ to: encodeBool(val) })
   })
 
-  const showRelative = computed({
+  const showPercentage = computed({
     get: () => decodeBool(route.query.r as string) ?? true,
     set: (val: boolean) => updateQuery({ r: encodeBool(val) })
   })
@@ -146,7 +146,7 @@ export function useRankingState() {
     showASMR: showASMR.value,
     showTotals: showTotals.value,
     showTotalsOnly: showTotalsOnly.value,
-    showRelative: showRelative.value,
+    showPercentage: showPercentage.value,
     showPI: showPI.value,
     cumulative: cumulative.value,
     hideIncomplete: hideIncomplete.value,
@@ -256,7 +256,7 @@ export function useRankingState() {
     showASMR,
     showTotals,
     showTotalsOnly,
-    showRelative,
+    showPercentage,
     showPI,
     cumulative,
     hideIncomplete,

--- a/app/lib/ranking/dataProcessing.test.ts
+++ b/app/lib/ranking/dataProcessing.test.ts
@@ -160,7 +160,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: codes => `/explorer?c=${codes.join(',')}`,
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -183,7 +183,7 @@ describe('ranking/dataProcessing', () => {
           dataLabels: ['2020'],
           metaData: createMockMetadata(code),
           explorerLink: () => '/',
-          display: { showRelative: false, cumulative: false, hideIncomplete: false },
+          display: { showPercentage: false, cumulative: false, hideIncomplete: false },
           totalRowKey: 'TOTAL'
         }
 
@@ -192,7 +192,7 @@ describe('ranking/dataProcessing', () => {
       })
     })
 
-    it('should calculate absolute values when showRelative is false', () => {
+    it('should calculate absolute values when showPercentage is false', () => {
       const options: ProcessCountryRowOptions = {
         iso3c: 'USA',
         countryData: createMockCountryData([10, 20, 30], [100, 100, 100]),
@@ -201,7 +201,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -212,7 +212,7 @@ describe('ranking/dataProcessing', () => {
       expect(row['2022']).toBe(30)
     })
 
-    it('should calculate relative values when showRelative is true', () => {
+    it('should calculate relative values when showPercentage is true', () => {
       const options: ProcessCountryRowOptions = {
         iso3c: 'USA',
         countryData: createMockCountryData([10, 20, 30], [100, 100, 100]),
@@ -221,7 +221,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: true, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: true, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -242,7 +242,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: true, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: true, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -263,7 +263,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -287,7 +287,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -309,7 +309,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -333,7 +333,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: true },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: true },
         totalRowKey: 'TOTAL'
       }
 
@@ -352,7 +352,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: true },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: true },
         totalRowKey: 'TOTAL'
       }
 
@@ -372,7 +372,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2020', '2021', '2022'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 
@@ -391,7 +391,7 @@ describe('ranking/dataProcessing', () => {
         dataLabels: ['2021', '2022', '2023'],
         metaData: createMockMetadata('USA'),
         explorerLink: () => '/',
-        display: { showRelative: false, cumulative: false, hideIncomplete: false },
+        display: { showPercentage: false, cumulative: false, hideIncomplete: false },
         totalRowKey: 'TOTAL'
       }
 

--- a/app/lib/ranking/dataProcessing.ts
+++ b/app/lib/ranking/dataProcessing.ts
@@ -64,7 +64,7 @@ export function processCountryRow(options: ProcessCountryRowOptions): { row: Tab
     dataLabels,
     metaData,
     explorerLink,
-    display: { showRelative, cumulative, hideIncomplete },
+    display: { showPercentage, cumulative, hideIncomplete },
     totalRowKey
   } = options
 
@@ -109,7 +109,7 @@ export function processCountryRow(options: ProcessCountryRowOptions): { row: Tab
   )
 
   // Calculate relative excess if needed
-  if (showRelative) {
+  if (showPercentage) {
     const { excessCum, excessCumLower, excessCumUpper } = calculateRelativeExcessArrays(
       cumMetric,
       cumMetricLower,
@@ -143,7 +143,7 @@ export function processCountryRow(options: ProcessCountryRowOptions): { row: Tab
     const label = dataLabels[i]
     if (!label) continue
 
-    if (showRelative) {
+    if (showPercentage) {
       const metVal = metricVal[i]
       const metLower = metricLower[i]
       const metUpper = metricUpper[i]

--- a/app/lib/ranking/types.ts
+++ b/app/lib/ranking/types.ts
@@ -28,7 +28,7 @@ export interface TableData {
 
 export interface TableDisplay {
   showTotals: boolean
-  showRelative: boolean
+  showPercentage: boolean
   showPI: boolean
   totalRowKey: string
   selectedBaselineMethod: string
@@ -67,7 +67,7 @@ export interface ProcessCountryRowOptions {
   metaData: Record<string, import('@/model').Country>
   explorerLink: (codes: string[]) => string
   display: {
-    showRelative: boolean
+    showPercentage: boolean
     cumulative: boolean
     hideIncomplete: boolean
   }

--- a/app/model/rankingSchema.test.ts
+++ b/app/model/rankingSchema.test.ts
@@ -9,7 +9,7 @@ describe('rankingSchema', () => {
     showASMR: true,
     showTotals: true,
     showTotalsOnly: false,
-    showRelative: true,
+    showPercentage: true,
     showPI: false,
     cumulative: false,
     hideIncomplete: true,

--- a/app/model/rankingSchema.ts
+++ b/app/model/rankingSchema.ts
@@ -58,7 +58,7 @@ const rankingStateBaseSchema = z.object({
   showASMR: z.boolean(),
   showTotals: z.boolean(),
   showTotalsOnly: z.boolean(),
-  showRelative: z.boolean(),
+  showPercentage: z.boolean(),
   showPI: z.boolean(), // Prediction intervals
   cumulative: z.boolean(),
   hideIncomplete: z.boolean(),

--- a/app/pages/ranking.url.test.ts
+++ b/app/pages/ranking.url.test.ts
@@ -73,7 +73,7 @@ describe('ranking URL state encoding/decoding', () => {
      * - a: showASMR
      * - t: showTotals
      * - to: showTotalsOnly
-     * - r: showRelative
+     * - r: showPercentage
      * - c: cumulative
      * - pi: showPI
      * - i: hideIncomplete (inverted)
@@ -132,7 +132,7 @@ describe('ranking URL state encoding/decoding', () => {
       const state = {
         showASMR: true,
         showTotals: true,
-        showRelative: true,
+        showPercentage: true,
         cumulative: false,
         hideIncomplete: false
       }
@@ -140,7 +140,7 @@ describe('ranking URL state encoding/decoding', () => {
       const params = new URLSearchParams()
       params.set('a', String(encodeBool(state.showASMR)))
       params.set('t', String(encodeBool(state.showTotals)))
-      params.set('r', String(encodeBool(state.showRelative)))
+      params.set('r', String(encodeBool(state.showPercentage)))
       params.set('c', String(encodeBool(state.cumulative)))
       params.set('i', String(encodeBool(!state.hideIncomplete))) // Inverted
 
@@ -158,14 +158,14 @@ describe('ranking URL state encoding/decoding', () => {
       const state = {
         showASMR: decodeBool(params.get('a') || '1'),
         showTotals: decodeBool(params.get('t') || '1'),
-        showRelative: decodeBool(params.get('r') || '1'),
+        showPercentage: decodeBool(params.get('r') || '1'),
         cumulative: decodeBool(params.get('c') || '0'),
         hideIncomplete: !decodeBool(params.get('i') || '0') // Inverted
       }
 
       expect(state.showASMR).toBe(true)
       expect(state.showTotals).toBe(true)
-      expect(state.showRelative).toBe(true)
+      expect(state.showPercentage).toBe(true)
       expect(state.cumulative).toBe(false)
       expect(state.hideIncomplete).toBe(true) // Inverted from i=0
     })
@@ -221,14 +221,14 @@ describe('ranking URL state encoding/decoding', () => {
       const defaults = {
         showASMR: true,
         showTotals: true,
-        showRelative: true,
+        showPercentage: true,
         cumulative: false
       }
 
       // Encode defaults
       expect(encodeBool(defaults.showASMR)).toBe(1)
       expect(encodeBool(defaults.showTotals)).toBe(1)
-      expect(encodeBool(defaults.showRelative)).toBe(1)
+      expect(encodeBool(defaults.showPercentage)).toBe(1)
       expect(encodeBool(defaults.cumulative)).toBe(0)
     })
 

--- a/app/pages/ranking.vue
+++ b/app/pages/ranking.vue
@@ -69,7 +69,7 @@ const {
   showASMR,
   showTotals,
   showTotalsOnly,
-  showRelative,
+  showPercentage,
   showPI,
   cumulative,
   hideIncomplete,
@@ -271,7 +271,7 @@ const subtitle = computed(() => {
 
 const displaySettings = computed(() => ({
   showTotals: showTotals.value,
-  showRelative: showRelative.value,
+  showPercentage: showPercentage.value,
   showPI: showPI.value,
   totalRowKey: 'TOTAL',
   selectedBaselineMethod: selectedBaselineMethod.value?.value || 'mean',
@@ -332,7 +332,7 @@ const rankingStateData = computed(() => ({
   dp: selectedDecimalPrecision.value.value,
   t: showTotals.value,
   to: showTotalsOnly.value,
-  r: showRelative.value,
+  r: showPercentage.value,
   pi: showPI.value,
   c: cumulative.value,
   i: !hideIncomplete.value,
@@ -457,7 +457,7 @@ const copyRankingLink = () => {
             v-model:show-totals="showTotals"
             v-model:show-totals-only="showTotalsOnly"
             v-model:hide-incomplete="hideIncomplete"
-            v-model:show-relative="showRelative"
+            v-model:show-percentage="showPercentage"
             v-model:cumulative="cumulative"
             v-model:show-p-i="showPI"
             v-model:selected-baseline-method="selectedBaselineMethod"
@@ -513,7 +513,7 @@ const copyRankingLink = () => {
             v-model:show-totals="showTotals"
             v-model:show-totals-only="showTotalsOnly"
             v-model:hide-incomplete="hideIncomplete"
-            v-model:show-relative="showRelative"
+            v-model:show-percentage="showPercentage"
             v-model:cumulative="cumulative"
             v-model:show-p-i="showPI"
             v-model:selected-baseline-method="selectedBaselineMethod"


### PR DESCRIPTION
Fixes #139

## Changes
- Replaced "Relative" with "Percentage" across Ranking UI and logic
- Updated state schemas: `showRelative` → `showPercentage`
- Updated UI labels in RankingSettings component
- Updated all type definitions and interfaces
- Updated data processing logic and composables
- Updated all test files to reflect new terminology
- Maintained backward compatibility with URL parameter 'r'

## Testing
- Verified terminology consistent across Explorer and Ranking pages
- All ranking-specific files updated (12 files changed)
- Manual verification: no instances of "showRelative" remain in ranking code
- URL parameter 'r' still works for backward compatibility

## Implementation Details
Files modified:
- **Schemas**: `app/model/rankingSchema.ts`, `app/model/rankingSchema.test.ts`
- **Types**: `app/lib/ranking/types.ts`
- **Components**: `app/components/ranking/RankingSettings.vue`, `app/components/RankingTable.vue`
- **Composables**: `app/composables/useRankingState.ts`, `app/composables/useRankingData.ts`
- **Logic**: `app/lib/ranking/dataProcessing.ts`
- **Tests**: All corresponding test files
- **Page**: `app/pages/ranking.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)