### PR TITLE
fix: resolve ranking toast error when switching ASMR/CMR (#162)

### DIFF
--- a/app/model/rankingSchema.test.ts
+++ b/app/model/rankingSchema.test.ts
@@ -5,7 +5,7 @@ describe('rankingSchema', () => {
   // Helper to create a valid base state
   const createValidState = (): RankingState => ({
     periodOfTime: 'fluseason',
-    jurisdictionType: 'country',
+    jurisdictionType: 'countries',
     showASMR: true,
     showTotals: true,
     showTotalsOnly: false,

--- a/app/model/rankingSchema.ts
+++ b/app/model/rankingSchema.ts
@@ -30,8 +30,18 @@ export const RankingPeriodEnum = z.enum([
 ])
 
 export const JurisdictionTypeEnum = z.enum([
-  'country',
-  'subdivision'
+  'countries',
+  'countries_states',
+  'usa',
+  'can',
+  'eu27',
+  'deu',
+  'af',
+  'as',
+  'eu',
+  'na',
+  'oc',
+  'sa'
 ])
 
 // Export TypeScript types from Zod enums


### PR DESCRIPTION
Fixes #162

## Changes
- **Root cause**: JurisdictionTypeEnum schema used singular values ('country', 'subdivision') but the application uses plural and specific values ('countries', 'countries_states', 'usa', 'can', etc.)
- **Fix**: Updated JurisdictionTypeEnum schema in rankingSchema.ts to match all actual jurisdiction type values from config.ts
- **Test update**: Fixed rankingSchema.test.ts to use valid 'countries' value instead of 'country'

## Testing
- All unit tests pass (305 tests across all test files)
- rankingSchema tests pass with updated jurisdiction values
- Type checking passes (npm run typecheck)
- Linting passes (npm run lint)
- Schema now correctly validates all jurisdiction type values used in the ranking page

## Impact
Users can now switch between ASMR and CMR modes without seeing the validation error toast:
- ASMR → CMR: no error toast
- CMR → ASMR: no error toast
- All jurisdiction types work correctly with validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)