### PR TITLE
refactor: standardize date formatting using formatChartDate utility

### DIFF
--- a/app/components/SubscriptionCard.vue
+++ b/app/components/SubscriptionCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { handleError } from '@/lib/errors/errorHandler'
+import { formatChartDate } from '@/lib/utils/dates'
 
 const { getSubscriptionStatus, manageSubscription, subscribe } = useStripe()
 
@@ -168,7 +169,7 @@ onActivated(() => {
               {{ subscriptionStatus.subscription.cancelAtPeriodEnd ? 'Active Until' : 'Renews On' }}
             </label>
             <p class="text-base text-gray-900 dark:text-gray-100">
-              {{ new Date(subscriptionStatus.subscription.currentPeriodEnd).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
+              {{ formatChartDate(subscriptionStatus.subscription.currentPeriodEnd, 'en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
             </p>
             <p
               v-if="subscriptionStatus.subscription.daysRemaining !== null"

--- a/app/components/profile/ProfileAccountInfo.vue
+++ b/app/components/profile/ProfileAccountInfo.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { User } from '#db/schema'
+import { formatChartDate } from '@/lib/utils/dates'
 
 type AuthUser = Omit<User, 'passwordHash'>
 
@@ -60,7 +61,7 @@ defineProps<{
           Member Since
         </label>
         <p class="text-base text-gray-900 dark:text-gray-100">
-          {{ new Date(user.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
+          {{ formatChartDate(user.createdAt, 'en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}
         </p>
       </div>
     </div>

--- a/app/pages/charts/[slug].vue
+++ b/app/pages/charts/[slug].vue
@@ -213,6 +213,7 @@ import { handleSilentError } from '@/lib/errors/errorHandler'
 import { showToast } from '@/toast'
 import { encodeChartState } from '@/lib/chartState'
 import type { ChartState } from '@/lib/chartState'
+import { formatChartDate } from '@/lib/utils/dates'
 
 const { user } = useAuth()
 const isAdmin = computed(() => user.value?.role === 'admin')
@@ -361,9 +362,9 @@ function copyToClipboard(text: string) {
   })
 }
 
-// Format dates
+// Format dates using utility
 function formatDate(dateString: string) {
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return formatChartDate(dateString, 'en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric'
@@ -371,7 +372,7 @@ function formatDate(dateString: string) {
 }
 
 function formatDateTime(dateString: string) {
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return formatChartDate(dateString, 'en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',


### PR DESCRIPTION
Follows up on PR #176 review feedback to standardize all date formatting across the application.

## Changes

Consolidate all inline date formatting to use the centralized `formatChartDate()` utility function from `app/lib/utils/dates.ts`:

- **charts/[slug].vue**: Replace inline `formatDate`/`formatDateTime` functions with `formatChartDate()` utility
- **profile/ProfileAccountInfo.vue**: Replace inline `toLocaleDateString` with `formatChartDate()`
- **SubscriptionCard.vue**: Replace inline `toLocaleDateString` with `formatChartDate()`

## Benefits

✅ **Consistency**: Single source of truth for date formatting across the app  
✅ **Flexibility**: `formatChartDate()` handles multiple input formats (Date, ISO string, Unix timestamps)  
✅ **Maintainability**: Changes to date formatting logic only need to be made in one place  
✅ **Error handling**: Built-in validation and 'Invalid date' fallback

## Testing

- ✅ TypeScript type checks pass
- ✅ All 823 unit tests pass  
- ✅ No breaking changes

## Context

This addresses the review feedback from PR #176:
> **Minor suggestion:** Standardize on `formatChartDate()` utility across all date formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)