### PR TITLE
feat: add z-score toggle to DisplayTab

### DIFF
--- a/app/components/charts/MortalityChartControlsSecondary.vue
+++ b/app/components/charts/MortalityChartControlsSecondary.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
   isUpdating: boolean
   isPopulationType: boolean
   isExcess: boolean
+  isZScore: boolean
   baselineMethod: string
   baselineSliderValue: string[]
   showBaseline: boolean
@@ -61,6 +62,7 @@ const emit = defineEmits<{
   chartStyleChanged: [value: string]
   standardPopulationChanged: [value: string]
   isExcessChanged: [value: boolean]
+  isZScoreChanged: [value: boolean]
   showBaselineChanged: [value: boolean]
   baselineMethodChanged: [value: string]
   baselineSliderValueChanged: [value: string[]]
@@ -145,6 +147,11 @@ const selectedBaselineMethod = computed({
 const isExcess = computed({
   get: () => props.isExcess,
   set: (v: boolean) => emit('isExcessChanged', v)
+})
+
+const isZScore = computed({
+  get: () => props.isZScore,
+  set: (v: boolean) => emit('isZScoreChanged', v)
 })
 
 const showBaseline = computed({
@@ -328,6 +335,7 @@ const activeTab = ref('data')
       <DisplayTab
         v-if="activeTab === 'display'"
         :is-excess="props.isExcess"
+        :is-z-score="props.isZScore"
         :show-baseline="props.showBaseline"
         :show-prediction-interval="props.showPredictionInterval"
         :maximize="props.maximize"
@@ -349,6 +357,7 @@ const activeTab = ref('data')
         :chart-preset="chartPreset"
         :chart-preset-options="chartPresetOptions"
         @update:is-excess="isExcess = $event"
+        @update:is-z-score="isZScore = $event"
         @update:show-baseline="showBaseline = $event"
         @update:show-prediction-interval="showPredictionInterval = $event"
         @update:maximize="maximize = $event"

--- a/app/components/charts/controls/DisplayTab.vue
+++ b/app/components/charts/controls/DisplayTab.vue
@@ -4,6 +4,7 @@ import { computed } from 'vue'
 const props = defineProps<{
   // Boolean switches
   isExcess: boolean
+  isZScore: boolean
   showBaseline: boolean
   showPredictionInterval: boolean
   maximize: boolean
@@ -31,6 +32,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:isExcess': [value: boolean]
+  'update:isZScore': [value: boolean]
   'update:showBaseline': [value: boolean]
   'update:showPredictionInterval': [value: boolean]
   'update:maximize': [value: boolean]
@@ -45,6 +47,11 @@ const emit = defineEmits<{
 const isExcessModel = computed({
   get: () => props.isExcess,
   set: v => emit('update:isExcess', v)
+})
+
+const isZScoreModel = computed({
+  get: () => props.isZScore,
+  set: v => emit('update:isZScore', v)
 })
 
 const showBaselineModel = computed({
@@ -104,6 +111,26 @@ const chartPresetModel = computed({
           test-id="excess-toggle"
           help-content="Compares observed mortality to expected baseline. Positive values indicate more deaths than expected, negative values indicate fewer deaths."
         />
+
+        <FeatureGate feature="Z_SCORES">
+          <UiControlRow>
+            <label class="text-sm font-medium whitespace-nowrap">
+              Z-Score
+              <FeatureBadge
+                feature="Z_SCORES"
+                class="ml-2"
+              />
+            </label>
+            <USwitch
+              v-model="isZScoreModel"
+              :disabled="props.isPopulationType"
+              data-testid="z-score-toggle"
+            />
+            <template #help>
+              Statistical measure of how many standard deviations the observed value is from the expected baseline. Values beyond ±2 indicate statistical significance.
+            </template>
+          </UiControlRow>
+        </FeatureGate>
 
         <UiSwitchRow
           v-model="showBaselineModel"

--- a/app/components/explorer/ExplorerSettings.vue
+++ b/app/components/explorer/ExplorerSettings.vue
@@ -18,6 +18,7 @@ const emit = defineEmits<{
   chartStyleChanged: [value: string]
   standardPopulationChanged: [value: string]
   isExcessChanged: [value: boolean]
+  isZScoreChanged: [value: boolean]
   showBaselineChanged: [value: boolean]
   baselineMethodChanged: [value: string]
   baselineSliderValueChanged: [value: string[]]
@@ -96,6 +97,7 @@ const baselineSliderValue = computed(() => {
       :is-updating="false"
       :is-population-type="isPopulationType"
       :is-excess="props.state.isExcess.value"
+      :is-z-score="props.state.isZScore.value"
       :baseline-method="props.state.baselineMethod.value"
       :baseline-slider-value="baselineSliderValue"
       :show-baseline="props.state.showBaseline.value"
@@ -131,6 +133,7 @@ const baselineSliderValue = computed(() => {
       @chart-style-changed="emit('chartStyleChanged', $event)"
       @standard-population-changed="emit('standardPopulationChanged', $event)"
       @is-excess-changed="emit('isExcessChanged', $event)"
+      @is-z-score-changed="emit('isZScoreChanged', $event)"
       @show-baseline-changed="emit('showBaselineChanged', $event)"
       @baseline-method-changed="emit('baselineMethodChanged', $event)"
       @baseline-slider-value-changed="emit('baselineSliderValueChanged', $event)"

--- a/app/composables/useExplorerState.ts
+++ b/app/composables/useExplorerState.ts
@@ -186,6 +186,11 @@ export function useExplorerState() {
    */
   const isExcess = computed(() => view.value === 'excess')
 
+  /**
+   * Check if current view is z-score
+   */
+  const isZScore = computed(() => view.value === 'zscore')
+
   // ============================================================================
   // VALIDATION - Gather complete state and validate
   // ============================================================================
@@ -324,6 +329,7 @@ export function useExplorerState() {
       ageGroups: ageGroups.value,
       standardPopulation: standardPopulation.value,
       isExcess: isExcess.value,
+      isZScore: isZScore.value,
       showBaseline: showBaseline.value,
       showPredictionInterval: showPredictionInterval.value,
       cumulative: cumulative.value,
@@ -358,6 +364,7 @@ export function useExplorerState() {
     // View (derived from URL)
     view,
     isExcess, // Backward compat: computed from view === 'excess'
+    isZScore, // Computed from view === 'zscore'
 
     // Core settings
     countries,

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -324,6 +324,31 @@ const handleExcessChanged = async (v: boolean) => {
   // Trigger chart refresh
   await update('_view')
 }
+
+// Special handler for z-score toggle - uses StateResolver for proper view transitions
+const handleZScoreChanged = async (v: boolean) => {
+  const router = useRouter()
+  const route = useRoute()
+
+  // Determine new view (z-score and excess are mutually exclusive)
+  const newView = v ? 'zscore' : 'mortality'
+
+  // Resolve view change through StateResolver
+  // This applies view defaults, constraints, and computes UI state
+  const { StateResolver } = await import('@/lib/state/StateResolver')
+  const resolved = StateResolver.resolveViewChange(
+    newView,
+    state.getCurrentStateValues(),
+    state.getUserOverrides()
+  )
+
+  // Apply resolved state to URL
+  await StateResolver.applyResolvedState(resolved, route, router)
+
+  // Trigger chart refresh
+  await update('_view')
+}
+
 const handleBaselineChanged = (v: boolean) => handleStateChange('showBaseline', v, '_showBaseline')
 const handlePredictionIntervalChanged = (v: boolean) => handleStateChange('showPredictionInterval', v, '_showPredictionInterval')
 const handleTypeChanged = (v: string) => handleStateChange('type', v, '_type')
@@ -644,6 +669,7 @@ watch(
             @chart-style-changed="handleChartStyleChanged"
             @standard-population-changed="handleStandardPopulationChanged"
             @is-excess-changed="handleExcessChanged"
+            @is-z-score-changed="handleZScoreChanged"
             @show-baseline-changed="handleBaselineChanged"
             @baseline-method-changed="handleBaselineMethodChanged"
             @baseline-slider-value-changed="baselineSliderChanged"


### PR DESCRIPTION
Add dedicated z-score analysis toggle following the same pattern as the excess toggle. The toggle is gated behind the Z_SCORES Pro feature and uses StateResolver for proper view transitions.

Changes:
- Add isZScore computed to useExplorerState (derived from view)
- Add handleZScoreChanged handler in explorer.vue using StateResolver
- Wire event through ExplorerSettings component
- Add isZScore prop/emit/computed to MortalityChartControlsSecondary
- Add z-score toggle UI in DisplayTab with Pro feature gate
- Toggle is mutually exclusive with excess (handled by StateResolver)
- Disabled when population type is selected (same as excess)

The z-score toggle switches between mortality/zscore views using the existing view system infrastructure. When enabled, it triggers StateResolver.resolveViewChange() to handle all state constraints and cascading changes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)