### PR TITLE
fix: remove as any type casts from database schema

### DIFF
--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -49,7 +49,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Validate and consume invite code if provided
-  let userTier = 1 // Default tier
+  let userTier: 0 | 1 | 2 = 1 // Default tier
   let inviteCodeId: number | null = null
   let proExpiryDate: Date | null = null
 


### PR DESCRIPTION
## Summary
- Remove `as any` type casts from `users` and `inviteCodes` table definitions
- Restores TypeScript type safety for critical database tables

## Changes
- Reordered table definitions to resolve circular reference (inviteCodes before users)
- Fixed type annotation in `register.post.ts` for `userTier` variable
- Removed unused import

## Root Cause
Circular reference between tables:
- `users.invitedByCodeId` → `inviteCodes.id`
- `inviteCodes.createdBy` → `users.id`

Drizzle ORM handles this via arrow function callbacks.

## Test plan
- [x] All 1,475 unit tests pass
- [x] TypeScript check passes
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)