### PR TITLE
security: add rate limiting to authentication endpoints

### DIFF
--- a/server/api/auth/signin.post.ts
+++ b/server/api/auth/signin.post.ts
@@ -7,6 +7,7 @@ import {
   setAuthToken
 } from '../../utils/auth'
 import { AuthSuccessResponseSchema } from '../../schemas'
+import { RequestThrottle } from '../../utils/requestQueue'
 
 const signinSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -14,7 +15,23 @@ const signinSchema = z.object({
   remember: z.boolean().optional()
 })
 
+// Rate limiting: 5 attempts per 15 minutes per IP
+const signinRateLimit = new RequestThrottle(
+  15 * 60 * 1000, // 15 minutes
+  5 // 5 attempts
+)
+
 export default defineEventHandler(async (event) => {
+  // Rate limit by IP address
+  const clientIp = getRequestIP(event, { xForwardedFor: true }) ?? 'unknown'
+
+  if (!signinRateLimit.check(clientIp)) {
+    throw createError({
+      statusCode: 429,
+      message: 'Too many sign-in attempts. Please try again in 15 minutes.'
+    })
+  }
+
   // Parse and validate request body
   const body = await readBody(event)
   const result = signinSchema.safeParse(body)


### PR DESCRIPTION
SECURITY FIX: Authentication endpoints were vulnerable to brute force and credential stuffing attacks due to missing rate limiting.

Changes:
- signin.post.ts: Add IP-based rate limiting (5 attempts per 15 min)
- register.post.ts: Add IP-based rate limiting (5 attempts per hour)
- forgot-password.post.ts: Add email-based rate limiting (3 per hour)

Implementation uses RequestThrottle class from requestQueue.ts with in-memory tracking. Rate limits apply per IP (signin/register) or email (forgot-password) to prevent abuse while allowing legitimate use.

All 1475 tests passing. TypeScript checks passing.