### PR TITLE
fix: add path validation to prevent path traversal attacks

### DIFF
--- a/server/api/data/path-validation.test.ts
+++ b/server/api/data/path-validation.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+
+// Test the path validation regex pattern
+const VALID_PATH_PATTERN = /^(?:world_meta\.csv|[A-Z]{2,3}\/[a-z]+(?:_[\w-]+)?\.csv)$/
+
+describe('data path validation', () => {
+  describe('valid paths', () => {
+    it('should accept world_meta.csv', () => {
+      expect(VALID_PATH_PATTERN.test('world_meta.csv')).toBe(true)
+    })
+
+    it('should accept country/chartType.csv patterns', () => {
+      expect(VALID_PATH_PATTERN.test('USA/weekly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR/monthly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('DE/yearly.csv')).toBe(true)
+    })
+
+    it('should accept country/chartType_ageGroup.csv patterns', () => {
+      expect(VALID_PATH_PATTERN.test('USA/weekly_0-14.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR/monthly_15-64.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('USA/weekly_65-74.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('USA/weekly_85plus.csv')).toBe(true)
+    })
+
+    it('should accept 2-letter and 3-letter country codes', () => {
+      expect(VALID_PATH_PATTERN.test('US/weekly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('USA/weekly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GB/monthly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR/monthly.csv')).toBe(true)
+    })
+  })
+
+  describe('path traversal attacks', () => {
+    it('should reject paths with ../', () => {
+      expect(VALID_PATH_PATTERN.test('../etc/passwd')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USA/../../../etc/passwd')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('../../.data/db.sqlite')).toBe(false)
+    })
+
+    it('should reject absolute paths', () => {
+      expect(VALID_PATH_PATTERN.test('/etc/passwd')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('/Users/ben/.ssh/id_rsa')).toBe(false)
+    })
+
+    it('should reject paths with encoded traversal', () => {
+      expect(VALID_PATH_PATTERN.test('%2e%2e/etc/passwd')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('..%2f..%2fetc/passwd')).toBe(false)
+    })
+  })
+
+  describe('invalid path formats', () => {
+    it('should reject paths with wrong extension', () => {
+      expect(VALID_PATH_PATTERN.test('USA/weekly.json')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USA/weekly.txt')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('world_meta.json')).toBe(false)
+    })
+
+    it('should reject paths with lowercase country codes', () => {
+      expect(VALID_PATH_PATTERN.test('usa/weekly.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('gbr/monthly.csv')).toBe(false)
+    })
+
+    it('should reject paths with uppercase chart types', () => {
+      expect(VALID_PATH_PATTERN.test('USA/WEEKLY.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USA/Weekly.csv')).toBe(false)
+    })
+
+    it('should reject paths with extra directories', () => {
+      expect(VALID_PATH_PATTERN.test('USA/subdir/weekly.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('region/USA/weekly.csv')).toBe(false)
+    })
+
+    it('should reject paths with special characters', () => {
+      expect(VALID_PATH_PATTERN.test('USA/weekly;ls.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USA/weekly|cat.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USA/weekly`id`.csv')).toBe(false)
+    })
+
+    it('should reject empty or malformed paths', () => {
+      expect(VALID_PATH_PATTERN.test('')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('/')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USA/')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('/USA/weekly.csv')).toBe(false)
+    })
+
+    it('should reject country codes that are too long or short', () => {
+      expect(VALID_PATH_PATTERN.test('U/weekly.csv')).toBe(false)
+      expect(VALID_PATH_PATTERN.test('USAA/weekly.csv')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes **CRITICAL** security vulnerability: path traversal attack in `/api/data/[...path]` endpoint
- Attacker could request paths like `../../etc/passwd` to read arbitrary files or construct malicious S3 URLs
- Adds strict allowlist validation with regex pattern for expected paths
- Adds resolved path boundary check to ensure access stays within cache directory
- Adds 14 unit tests covering valid paths and attack vectors

## Changes

1. **Path validation function** (`validatePath`):
   - Normalizes path to catch encoded traversal attempts
   - Rejects paths containing `..`, absolute paths, null bytes
   - Validates against strict regex: `world_meta.csv` or `{COUNTRY}/{chartType}[_ageGroup].csv`

2. **Resolved path boundary check**:
   - Ensures resolved local path stays within `.data/cache/mortality/` directory
   - Defense in depth against any bypass of regex validation

3. **Test coverage**:
   - 14 unit tests for regex pattern validation
   - Tests valid paths (metadata, country data, age groups)
   - Tests attack vectors (traversal, absolute paths, special chars)

## Test plan

- [x] All 1494 unit tests pass
- [x] TypeScript typecheck passes
- [x] Manual testing: verify `/api/data/USA/weekly.csv` works
- [x] Manual testing: verify `/api/data/../../etc/passwd` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)