### PR TITLE
fix: use bs/be params for stats API baseline calculation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ NUXT_PUBLIC_INCOGNITO_MODE=0
 # Set to 'false' to allow S3 fallback when local files are missing
 NUXT_PUBLIC_USE_LOCAL_CACHE=false
 
+# Stats API URL for baseline calculations
+# Default: https://stats.mortality.watch/
+# For local development, use http://localhost:8000/
+NUXT_PUBLIC_STATS_URL=
+
 # Development countries - subset of countries to download and work with
 # Comma-separated list of ISO country codes
 # Leave empty to use default list (18 countries) or use --all flag

--- a/app/composables/useChartDataFetcher.test.ts
+++ b/app/composables/useChartDataFetcher.test.ts
@@ -39,6 +39,13 @@ vi.mock('@/model/baseline', () => ({
   defaultBaselineToDate: vi.fn()
 }))
 
+// Mock useRuntimeConfig
+vi.stubGlobal('useRuntimeConfig', () => ({
+  public: {
+    statsUrl: 'https://stats.mortality.watch/'
+  }
+}))
+
 describe('useChartDataFetcher', () => {
   const mockDataset: DatasetRaw = {
     USA: {
@@ -217,7 +224,8 @@ describe('useChartDataFetcher', () => {
       let progressCallback: ((progress: number, total: number) => void) | undefined
 
       vi.mocked(fetchAllChartData).mockImplementation(async (...args: any[]) => {
-        progressCallback = args[args.length - 1] as (progress: number, total: number) => void
+        // Progress callback is second to last arg (last is statsUrl)
+        progressCallback = args[args.length - 2] as (progress: number, total: number) => void
         if (progressCallback) {
           progressCallback(50, 100)
         }
@@ -241,7 +249,8 @@ describe('useChartDataFetcher', () => {
       let progressCallback: ((progress: number, total: number) => void) | undefined
 
       vi.mocked(fetchAllChartData).mockImplementation(async (...args: any[]) => {
-        progressCallback = args[args.length - 1] as (progress: number, total: number) => void
+        // Progress callback is second to last arg (last is statsUrl)
+        progressCallback = args[args.length - 2] as (progress: number, total: number) => void
         if (progressCallback) {
           progressCallback(75, 100)
         }
@@ -592,7 +601,8 @@ describe('useChartDataFetcher', () => {
         '2017',
         '2019',
         [],
-        expect.any(Function)
+        expect.any(Function),
+        'https://stats.mortality.watch/'
       )
     })
 
@@ -623,7 +633,8 @@ describe('useChartDataFetcher', () => {
         '2017',
         '2019',
         [],
-        expect.any(Function)
+        expect.any(Function),
+        'https://stats.mortality.watch/'
       )
     })
 

--- a/app/composables/useExplorerDataOrchestration.ts
+++ b/app/composables/useExplorerDataOrchestration.ts
@@ -336,6 +336,7 @@ export function useExplorerDataOrchestration(
         baselineDateFrom: state.baselineDateFrom.value ?? baselineRange.value?.from,
         baselineDateTo: state.baselineDateTo.value ?? baselineRange.value?.to,
         baselineStartIdx: undefined, // Will be calculated from labels
+        sliderStart: state.sliderStart.value, // Layer 2 offset
         cumulative: helpers.showCumPi(),
         baseKeys: helpers.getBaseKeysForFetch(),
         isAsmr: helpers.isAsmrType()
@@ -390,6 +391,7 @@ export function useExplorerDataOrchestration(
         baselineDateFrom: state.baselineDateFrom.value ?? baselineRange.value?.from,
         baselineDateTo: state.baselineDateTo.value ?? baselineRange.value?.to,
         baselineStartIdx: getStartIndex(allYearlyChartLabels.value || [], state.sliderStart.value),
+        sliderStart: state.sliderStart.value, // Layer 2 offset
         cumulative: helpers.showCumPi(),
         baseKeys: helpers.getBaseKeysForFetch(),
         isAsmr: helpers.isAsmrType()

--- a/app/composables/useRankingData.ts
+++ b/app/composables/useRankingData.ts
@@ -247,6 +247,7 @@ export function useRankingData(
       baselineMethod: state.baselineMethod.value || 'mean',
       baselineDateFrom: state.baselineDateFrom.value,
       baselineDateTo: state.baselineDateTo.value,
+      sliderStart: sliderStart.value, // Layer 2 offset
       cumulative: state.cumulative.value,
       isAsmr: type === 'asmr',
       baseKeys: getKeyForType(type, true, state.standardPopulation.value || 'who2015')

--- a/app/lib/data/aggregations.ts
+++ b/app/lib/data/aggregations.ts
@@ -16,6 +16,8 @@ import { calculateBaselines } from './baselines'
 
 /**
  * Get all chart data with optional baseline calculations
+ *
+ * @param statsUrl - Optional stats API URL for baseline calculations
  */
 export const getAllChartData = async (
   dataKey: keyof CountryData,
@@ -30,7 +32,8 @@ export const getAllChartData = async (
   baselineDateFrom?: string,
   baselineDateTo?: string,
   keys?: (keyof NumberEntryFields)[],
-  progressCb?: (progress: number, total: number) => void
+  progressCb?: (progress: number, total: number) => void,
+  statsUrl?: string
 ): Promise<AllChartData> => {
   const data: Dataset = {}
   const ageGroups = ageGroupFilter ?? Object.keys(rawData || {})
@@ -123,7 +126,8 @@ export const getAllChartData = async (
       baselineMethod,
       chartType,
       cumulative,
-      progressCb
+      progressCb,
+      statsUrl
     )
   }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -39,7 +39,8 @@ export default defineNuxtConfig({
       devCountries: process.env.NUXT_PUBLIC_DEV_COUNTRIES || '',
       dataCachePath: '.data/cache/mortality',
       siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://www.mortality.watch',
-      stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY || ''
+      stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY || '',
+      statsUrl: process.env.NUXT_PUBLIC_STATS_URL || 'https://stats.mortality.watch/'
     }
   },
 
@@ -89,7 +90,8 @@ export default defineNuxtConfig({
             'style-src \'self\' \'unsafe-inline\'',
             'img-src \'self\' data: https:',
             'font-src \'self\' data:',
-            'connect-src \'self\' https://s3.mortality.watch https://stats.mortality.watch https://api.stripe.com',
+            // Allow localhost for local stats API development
+            'connect-src \'self\' https://s3.mortality.watch https://stats.mortality.watch https://api.stripe.com http://localhost:*',
             'frame-src https://js.stripe.com',
             'child-src https://js.stripe.com'
           ].join('; ')


### PR DESCRIPTION
## Summary
- Replace old `b` parameter with `bs`/`be` (baseline start/end, 1-indexed)
- Add configurable `NUXT_PUBLIC_STATS_URL` for local development
- Pass `sliderStart` through call chain for proper Layer 2 offset
- Update CSP to allow localhost for local stats server
- Remove `h` parameter (not needed with `bs`/`be`)

The stats API now receives explicit baseline range, allowing PI and z-scores to be calculated for all post-baseline periods.

## Test plan
- [ ] Verify stats API receives correct `bs`/`be` parameters
- [ ] Verify PI displays for all post-baseline periods
- [ ] Verify z-scores are calculated correctly
- [ ] Test with local stats server using `NUXT_PUBLIC_STATS_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)