### PR TITLE
fix: correct ASMR baseline field names in ranking page

### DIFF
--- a/app/composables/useChartDataFetcher.test.ts
+++ b/app/composables/useChartDataFetcher.test.ts
@@ -50,7 +50,7 @@ describe('useChartDataFetcher', () => {
   const mockDataset: DatasetRaw = {
     USA: {
       all: [
-        { cmr: 100, asmr_who2015: 50 } as any
+        { cmr: 100, asmr_who: 50 } as any
       ]
     }
   }
@@ -568,7 +568,7 @@ describe('useChartDataFetcher', () => {
         chartType: 'yearly' as ChartType,
         countries: ['USA'],
         ageGroups: ['all'],
-        dataKey: 'asmr_who2015' as keyof CountryData,
+        dataKey: 'asmr_who' as keyof CountryData,
         baselineMethod: 'mean',
         isAsmr: true
       })

--- a/app/composables/useExplorerDataOrchestration.test.ts
+++ b/app/composables/useExplorerDataOrchestration.test.ts
@@ -147,7 +147,7 @@ describe('useExplorerDataOrchestration', () => {
       chartType: ref('yearly'),
       ageGroups: ref(['all']),
       type: ref('cmr'),
-      standardPopulation: ref('who2015'),
+      standardPopulation: ref('who'),
       showBaseline: ref(true),
       baselineMethod: ref('mean'),
       baselineDateFrom: ref('2017'),

--- a/app/composables/useRankingData.test.ts
+++ b/app/composables/useRankingData.test.ts
@@ -130,7 +130,7 @@ describe('useRankingData', () => {
       periodOfTime: ref('yearly'),
       jurisdictionType: ref('all'),
       showASMR: ref(false),
-      standardPopulation: ref('who2015'),
+      standardPopulation: ref('who'),
       baselineMethod: ref('mean'),
       baselineDateFrom: ref('2017'),
       baselineDateTo: ref('2019'),
@@ -240,7 +240,7 @@ describe('useRankingData', () => {
 
       expect(mockDataFetcher.fetchChartData).toHaveBeenCalledWith(
         expect.objectContaining({
-          dataKey: 'asmr_who2015',
+          dataKey: 'asmr_who',
           isAsmr: true
         })
       )

--- a/app/composables/useRankingData.ts
+++ b/app/composables/useRankingData.ts
@@ -250,7 +250,7 @@ export function useRankingData(
       sliderStart: sliderStart.value, // Layer 2 offset
       cumulative: state.cumulative.value,
       isAsmr: type === 'asmr',
-      baseKeys: getKeyForType(type, true, state.standardPopulation.value || 'who2015')
+      baseKeys: getKeyForType(type, true, state.standardPopulation.value || 'who')
     })
 
     if (!result) {


### PR DESCRIPTION
## Summary
- Fixed bug where ranking page showed 0.0% for ASMR but CMR worked correctly
- Root cause: incorrect standardPopulation fallback value ('who2015' instead of 'who')
- This caused mismatched field names for baseline calculations

## Root Cause
In `useRankingData.ts` line 253, the code used `'who2015'` as the fallback value for `standardPopulation`. This caused `getKeyForType()` to generate incorrect field names like `'asmr_who2015_baseline'` instead of `'asmr_who_baseline'`.

The database and TypeScript types use standard population values without year suffixes:
- `'who'` (not `'who2015'`)
- `'esp'` (not `'esp2013'`)
- `'usa'` (not `'usa2000'`)
- `'country'`

## Changes
- Updated `useRankingData.ts` line 253: Changed fallback from `'who2015'` to `'who'`
- Fixed test files to use correct standard population values:
  - `useRankingData.test.ts`
  - `useExplorerDataOrchestration.test.ts`
  - `useChartDataFetcher.test.ts`

## Testing
- ✅ `npm run typecheck` - All types valid
- ✅ `npm run test` - All 1494 tests passing

## Impact
This ensures baseline calculations work correctly for ASMR in the ranking page. CMR was unaffected because it doesn't use the standardPopulation parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)