### PR TITLE
fix: eliminate double refresh when changing baseline period (Bug #8)

### DIFF
--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -180,6 +180,7 @@ const dateSliderChanged = async (val: string[]) => {
 
 const baselineSliderChanged = async (val: string[]) => {
   // IMPORTANT: Batch both updates into a single router.push to avoid race condition
+  // The browser navigation watcher will handle the data update when the URL changes
   const route = useRoute()
   const router = useRouter()
   const newQuery = { ...route.query }
@@ -187,8 +188,6 @@ const baselineSliderChanged = async (val: string[]) => {
   newQuery.bt = val[1]!
 
   await router.push({ query: newQuery })
-
-  update('_baselineDateFrom')
 }
 
 // Labels for the date range slider - full range from sliderStart to end


### PR DESCRIPTION
## Summary

Fixes Bug #8 where changing the baseline period slider caused the chart to refresh twice, showing "Loading data..." twice in quick succession.

## Root Cause

The `baselineSliderChanged()` function in `app/pages/explorer.vue` was causing a double refresh by:
1. Calling `router.push()` to update URL query params (`bf`, `bt`)
2. Then calling `update('_baselineDateFrom')` to trigger a manual data refresh

This caused two sequential data refreshes because the `useBrowserNavigation` watcher also detects the URL change and calls `update('_countries')`.

## Solution

Removed the manual `update('_baselineDateFrom')` call from `baselineSliderChanged()`. The browser navigation watcher now handles all updates when URL params change, providing a single, consistent update flow.

This matches the pattern already used in `dateSliderChanged()` and ensures baseline slider changes trigger exactly one data refresh.

## Changes

- **app/pages/explorer.vue**: Removed `update('_baselineDateFrom')` call from `baselineSliderChanged()` function
- Added clarifying comment explaining that the browser navigation watcher handles the update

## Testing

- ✅ All 1494 unit tests pass
- ✅ Type checking passes
- ✅ Linting passes
- ✅ Manual testing: Baseline slider now triggers single refresh

## Impact

Users will no longer see the loading indicator appear twice when adjusting the baseline period, resulting in a smoother, more responsive UI experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)