### PR TITLE
fix: enable logarithmic scale toggle for charts

### DIFF
--- a/app/components/charts/MortalityChart.vue
+++ b/app/components/charts/MortalityChart.vue
@@ -9,6 +9,7 @@ import {
   PointElement,
   CategoryScale,
   LinearScale,
+  LogarithmicScale,
   TimeScale,
   Tooltip,
   Legend,
@@ -50,6 +51,7 @@ const props = defineProps<{
   showPredictionInterval: boolean
   showPercentage: boolean
   showLabels: boolean
+  showLogarithmic: boolean
   isDeathsType: boolean
   isPopulationType: boolean
   showLogo: boolean
@@ -66,6 +68,7 @@ Chart.register(
   PointElement,
   CategoryScale,
   LinearScale,
+  LogarithmicScale,
   TimeScale,
   Tooltip,
   Legend,
@@ -108,7 +111,7 @@ const lineConfig = computed(() => {
   const isDark = colorMode.value === 'dark'
   if (props.chartStyle !== 'line') return undefined
   return makeBarLineChartConfig(
-    { ...props.data, showLabels: effectiveShowLabels.value },
+    { ...props.data, showLabels: effectiveShowLabels.value, showLogarithmic: props.showLogarithmic },
     props.isExcess,
     props.showPredictionInterval,
     props.showPercentage,
@@ -128,7 +131,7 @@ const barConfig = computed(() => {
   const isDark = colorMode.value === 'dark'
   if (props.chartStyle !== 'bar') return undefined
   return makeBarLineChartConfig(
-    { ...props.data, showLabels: effectiveShowLabels.value },
+    { ...props.data, showLabels: effectiveShowLabels.value, showLogarithmic: props.showLogarithmic },
     props.isExcess,
     props.showPredictionInterval,
     props.showPercentage,

--- a/app/components/charts/MortalityChartControlsSecondary.vue
+++ b/app/components/charts/MortalityChartControlsSecondary.vue
@@ -332,7 +332,7 @@ const activeTab = ref('data')
         @update:show-baseline="showBaseline = $event"
         @update:show-prediction-interval="showPredictionInterval = $event"
         @update:maximize="maximize = $event"
-        @update:is-logarithmic="showLogarithmic = $event"
+        @update:show-logarithmic="showLogarithmic = $event"
         @update:show-percentage="showPercentage = $event"
         @update:cumulative="cumulative = $event"
         @update:show-total="showTotal = $event"

--- a/app/components/explorer/ExplorerChartContainer.vue
+++ b/app/components/explorer/ExplorerChartContainer.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   showPredictionInterval: boolean
   showPercentage: boolean
   showLabels: boolean
+  showLogarithmic: boolean
   isDeathsType: boolean
   isPopulationType: boolean
   showLogo: boolean
@@ -73,6 +74,7 @@ defineExpose({
         :show-prediction-interval="props.showPredictionInterval"
         :show-percentage="props.showPercentage"
         :show-labels="props.showLabels"
+        :show-logarithmic="props.showLogarithmic"
         :is-deaths-type="props.isDeathsType"
         :is-population-type="props.isPopulationType"
         :show-logo="props.showLogo"

--- a/app/components/explorer/ExplorerSettings.vue
+++ b/app/components/explorer/ExplorerSettings.vue
@@ -138,7 +138,7 @@ const baselineSliderValue = computed(() => {
       @show-prediction-interval-changed="emit('showPredictionIntervalChanged', $event)"
       @show-labels-changed="emit('showLabelsChanged', $event)"
       @maximize-changed="emit('maximizeChanged', $event)"
-      @is-logarithmic-changed="emit('showLogarithmicChanged', $event)"
+      @show-logarithmic-changed="emit('showLogarithmicChanged', $event)"
       @show-percentage-changed="emit('showPercentageChanged', $event)"
       @cumulative-changed="emit('cumulativeChanged', $event)"
       @show-total-changed="emit('showTotalChanged', $event)"

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -664,6 +664,7 @@ watch(
             :show-prediction-interval="state.showPredictionInterval.value"
             :show-percentage="state.showPercentage.value"
             :show-labels="state.showLabels.value"
+            :show-logarithmic="state.showLogarithmic.value"
             :is-deaths-type="isDeathsType()"
             :is-population-type="isPopulationType()"
             :show-logo="state.showLogo.value"


### PR DESCRIPTION
## Summary
- Fix event name mismatch in ExplorerSettings (`@is-logarithmic-changed` → `@show-logarithmic-changed`)
- Register `LogarithmicScale` in Chart.js to fix "not a registered scale" error
- Pass `showLogarithmic` prop through component chain for reactivity

## Test plan
- [x] Go to explorer page with raw values view
- [x] Toggle "Log Scale" switch in Display tab
- [x] Verify switch toggles visually
- [x] Verify chart Y-axis changes to logarithmic scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)