### PR TITLE
refactor: move business logic from explorer.vue to orchestration layer

### DIFF
--- a/app/composables/useUpdateQueue.ts
+++ b/app/composables/useUpdateQueue.ts
@@ -1,0 +1,125 @@
+/**
+ * Update Queue Composable
+ *
+ * Manages concurrent update handling for the explorer page.
+ * Prevents race conditions by queuing updates when one is already in progress.
+ *
+ * Features:
+ * - Queues updates to prevent concurrent execution
+ * - Tracks internal URL updates vs browser navigation
+ * - Provides reactive state for UI feedback
+ */
+
+import { ref, computed } from 'vue'
+import {
+  requiresDataDownload,
+  requiresDatasetUpdate,
+  requiresFilterUpdate
+} from '@/lib/state'
+
+interface UpdateQueueOptions {
+  /**
+   * Callback to execute the actual data update
+   * @param shouldDownload - Whether to fetch fresh data from server
+   * @param shouldUpdate - Whether to recalculate baseline/dataset
+   */
+  onUpdate: (shouldDownload: boolean, shouldUpdate: boolean) => Promise<void>
+
+  /**
+   * Optional: Get current state for conditional field logic
+   * (e.g., cumulative needs 'update' if baselineMethod !== 'auto')
+   */
+  getCurrentState?: () => Record<string, unknown>
+}
+
+export function useUpdateQueue(options: UpdateQueueOptions) {
+  const { onUpdate, getCurrentState } = options
+
+  // Internal state
+  const isCurrentlyUpdating = ref(false)
+  const pendingUpdateKey = ref<string | null>(null)
+
+  // Flag to skip browser navigation handler when WE update the URL
+  // (vs when user clicks back/forward)
+  const isInternalUrlUpdate = ref(false)
+
+  /**
+   * Process an update request based on the field change key
+   */
+  const processUpdate = async (key: string) => {
+    const currentState = getCurrentState?.()
+
+    const shouldDownload = requiresDataDownload(key, currentState)
+    const shouldUpdate = requiresDatasetUpdate(key, currentState)
+    const shouldFilter = requiresFilterUpdate(key, currentState)
+
+    // Only call onUpdate if any data operation is needed
+    if (shouldDownload || shouldUpdate || shouldFilter) {
+      await onUpdate(shouldDownload, shouldUpdate)
+    }
+  }
+
+  /**
+   * Queue an update request.
+   * If an update is already in progress, the new request is queued.
+   * Only the most recent pending request is kept (latest wins).
+   *
+   * @param key - The field change key (e.g., '_countries', 'dateRange')
+   */
+  const queueUpdate = async (key: string) => {
+    // If already updating, queue this update
+    if (isCurrentlyUpdating.value) {
+      pendingUpdateKey.value = key
+      return
+    }
+
+    isCurrentlyUpdating.value = true
+    try {
+      await processUpdate(key)
+
+      // Process any pending update
+      if (pendingUpdateKey.value) {
+        const nextKey = pendingUpdateKey.value
+        pendingUpdateKey.value = null
+        await processUpdate(nextKey)
+      }
+    } finally {
+      isCurrentlyUpdating.value = false
+    }
+  }
+
+  /**
+   * Mark the start of an internal URL update.
+   * Call this before programmatically updating the URL to prevent
+   * the browser navigation handler from triggering a duplicate update.
+   */
+  const startInternalUrlUpdate = () => {
+    isInternalUrlUpdate.value = true
+  }
+
+  /**
+   * Mark the end of an internal URL update.
+   * Call this after the URL update is complete.
+   */
+  const endInternalUrlUpdate = () => {
+    isInternalUrlUpdate.value = false
+  }
+
+  /**
+   * Check if an update should be skipped (e.g., during internal URL changes)
+   */
+  const shouldSkipUpdate = computed(() => isInternalUrlUpdate.value)
+
+  return {
+    // State
+    isUpdating: computed(() => isCurrentlyUpdating.value),
+    hasPendingUpdate: computed(() => pendingUpdateKey.value !== null),
+    isInternalUrlUpdate: computed(() => isInternalUrlUpdate.value),
+    shouldSkipUpdate,
+
+    // Actions
+    queueUpdate,
+    startInternalUrlUpdate,
+    endInternalUrlUpdate
+  }
+}

--- a/app/lib/state/config/index.ts
+++ b/app/lib/state/config/index.ts
@@ -10,8 +10,16 @@
 // View configurations
 export { VIEWS } from './views'
 
-// Global constraints
-export { STATE_CONSTRAINTS } from './constraints'
+// Global constraints and field update strategy
+export {
+  STATE_CONSTRAINTS,
+  FIELD_UPDATE_STRATEGY,
+  type FieldUpdateType,
+  getFieldUpdateType,
+  requiresDataDownload,
+  requiresDatasetUpdate,
+  requiresFilterUpdate
+} from './constraints'
 
 // Field encoders and defaults
 export {

--- a/app/lib/state/resolver/StateResolver.test.ts
+++ b/app/lib/state/resolver/StateResolver.test.ts
@@ -157,4 +157,122 @@ describe('StateResolver', () => {
       expect(chartStyleChange).toBeUndefined()
     })
   })
+
+  describe('createSnapshot', () => {
+    it('should create a complete snapshot from resolved state', () => {
+      const resolvedState = {
+        countries: ['USA', 'GBR'],
+        type: 'deaths',
+        chartType: 'fluseason',
+        chartStyle: 'bar',
+        view: 'excess',
+        isExcess: true
+      }
+
+      const snapshot = StateResolver.createSnapshot(resolvedState)
+
+      expect(snapshot.countries).toEqual(['USA', 'GBR'])
+      expect(snapshot.type).toBe('deaths')
+      expect(snapshot.chartType).toBe('fluseason')
+      expect(snapshot.chartStyle).toBe('bar')
+      expect(snapshot.view).toBe('excess')
+      expect(snapshot.isExcess).toBe(true)
+    })
+
+    it('should use defaults for missing fields', () => {
+      const resolvedState = {
+        countries: ['USA']
+      }
+
+      const snapshot = StateResolver.createSnapshot(resolvedState)
+
+      expect(snapshot.countries).toEqual(['USA'])
+      // Default values should be used for missing fields
+      expect(snapshot.type).toBe('asmr')
+      expect(snapshot.chartStyle).toBe('line')
+      expect(snapshot.view).toBe('mortality')
+      expect(snapshot.isExcess).toBe(false)
+      expect(snapshot.isZScore).toBe(false)
+      expect(snapshot.showBaseline).toBe(true)
+      expect(snapshot.showPredictionInterval).toBe(true)
+    })
+
+    it('should merge resolved state with current state', () => {
+      const resolvedState = {
+        countries: ['FRA'],
+        type: 'deaths'
+      }
+      const currentState = {
+        countries: ['USA'],
+        type: 'asmr',
+        chartType: 'year',
+        chartStyle: 'matrix',
+        showBaseline: false
+      }
+
+      const snapshot = StateResolver.createSnapshot(resolvedState, currentState)
+
+      // Resolved state takes precedence
+      expect(snapshot.countries).toEqual(['FRA'])
+      expect(snapshot.type).toBe('deaths')
+      // Current state used for missing resolved fields
+      expect(snapshot.chartType).toBe('year')
+      expect(snapshot.chartStyle).toBe('matrix')
+      expect(snapshot.showBaseline).toBe(false)
+    })
+
+    it('should handle all ChartStateSnapshot fields', () => {
+      const resolvedState = {
+        countries: ['USA'],
+        type: 'asmr',
+        chartType: 'fluseason',
+        chartStyle: 'line',
+        ageGroups: ['all'],
+        standardPopulation: 'who',
+        view: 'mortality',
+        isExcess: false,
+        isZScore: false,
+        dateFrom: '2020-01',
+        dateTo: '2023-12',
+        sliderStart: '2010',
+        baselineDateFrom: '2015-01',
+        baselineDateTo: '2019-12',
+        showBaseline: true,
+        baselineMethod: 'mean',
+        cumulative: false,
+        showTotal: false,
+        maximize: false,
+        showPredictionInterval: true,
+        showLabels: true,
+        showPercentage: false,
+        showLogarithmic: false,
+        userColors: ['#ff0000', '#00ff00'],
+        decimals: 'auto'
+      }
+
+      const snapshot = StateResolver.createSnapshot(resolvedState)
+
+      // All fields should be present
+      expect(snapshot).toEqual(resolvedState)
+    })
+
+    it('should handle undefined date fields', () => {
+      const resolvedState = {
+        countries: ['USA'],
+        dateFrom: undefined,
+        dateTo: undefined,
+        baselineDateFrom: undefined,
+        baselineDateTo: undefined,
+        userColors: undefined
+      }
+
+      const snapshot = StateResolver.createSnapshot(resolvedState)
+
+      expect(snapshot.dateFrom).toBeUndefined()
+      expect(snapshot.dateTo).toBeUndefined()
+      expect(snapshot.baselineDateFrom).toBeUndefined()
+      expect(snapshot.baselineDateTo).toBeUndefined()
+      expect(snapshot.userColors).toBeUndefined()
+    })
+  })
 })

--- a/app/lib/state/resolver/StateResolver.ts
+++ b/app/lib/state/resolver/StateResolver.ts
@@ -18,6 +18,8 @@ import { getViewConstraints } from './viewConstraints'
 import type { ViewType } from './viewTypes'
 import { VIEWS } from '../config/views'
 import { computeUIState, type UIFieldState } from './uiStateComputer'
+import type { ChartStateSnapshot } from '@/lib/chart/types'
+import type { ChartType } from '@/model/period'
 
 /**
  * Get defaults for a view, with view-specific fields added
@@ -663,6 +665,55 @@ export class StateResolver {
       await router.replace({ query: newQuery })
     } else {
       await router.push({ query: newQuery })
+    }
+  }
+
+  /**
+   * Create a ChartStateSnapshot from a resolved state object.
+   *
+   * Used to generate chart data before applying resolved state to refs,
+   * ensuring consistent state during view transitions.
+   *
+   * This centralizes the snapshot creation logic that was previously
+   * duplicated in explorer.vue's createSnapshotFromResolved function.
+   *
+   * @param resolvedState - The resolved state object from StateResolver
+   * @param currentState - Optional current state to fill in missing fields
+   * @returns A complete ChartStateSnapshot ready for chart data generation
+   */
+  static createSnapshot(
+    resolvedState: Record<string, unknown>,
+    currentState?: Record<string, unknown>
+  ): ChartStateSnapshot {
+    // Use provided current state or empty object for fallbacks
+    const current = currentState ?? {}
+
+    return {
+      countries: (resolvedState.countries ?? current.countries ?? []) as string[],
+      type: (resolvedState.type ?? current.type ?? 'asmr') as string,
+      chartType: (resolvedState.chartType ?? current.chartType ?? 'fluseason') as ChartType,
+      chartStyle: (resolvedState.chartStyle ?? current.chartStyle ?? 'line') as string,
+      ageGroups: (resolvedState.ageGroups ?? current.ageGroups ?? ['all']) as string[],
+      standardPopulation: (resolvedState.standardPopulation ?? current.standardPopulation ?? 'who') as string,
+      view: (resolvedState.view ?? current.view ?? 'mortality') as string,
+      isExcess: (resolvedState.isExcess ?? current.isExcess ?? false) as boolean,
+      isZScore: (resolvedState.isZScore ?? current.isZScore ?? false) as boolean,
+      dateFrom: (resolvedState.dateFrom ?? current.dateFrom) as string | undefined,
+      dateTo: (resolvedState.dateTo ?? current.dateTo) as string | undefined,
+      sliderStart: (resolvedState.sliderStart ?? current.sliderStart ?? '2010') as string,
+      baselineDateFrom: (resolvedState.baselineDateFrom ?? current.baselineDateFrom) as string | undefined,
+      baselineDateTo: (resolvedState.baselineDateTo ?? current.baselineDateTo) as string | undefined,
+      showBaseline: (resolvedState.showBaseline ?? current.showBaseline ?? true) as boolean,
+      baselineMethod: (resolvedState.baselineMethod ?? current.baselineMethod ?? 'mean') as string,
+      cumulative: (resolvedState.cumulative ?? current.cumulative ?? false) as boolean,
+      showTotal: (resolvedState.showTotal ?? current.showTotal ?? false) as boolean,
+      maximize: (resolvedState.maximize ?? current.maximize ?? false) as boolean,
+      showPredictionInterval: (resolvedState.showPredictionInterval ?? current.showPredictionInterval ?? true) as boolean,
+      showLabels: (resolvedState.showLabels ?? current.showLabels ?? true) as boolean,
+      showPercentage: (resolvedState.showPercentage ?? current.showPercentage ?? false) as boolean,
+      showLogarithmic: (resolvedState.showLogarithmic ?? current.showLogarithmic ?? false) as boolean,
+      userColors: (resolvedState.userColors ?? current.userColors) as string[] | undefined,
+      decimals: (resolvedState.decimals ?? current.decimals ?? 'auto') as string
     }
   }
 }


### PR DESCRIPTION
## Summary

This refactoring implements the "dumb components, smart orchestration" principle for the explorer page architecture:

- **Extract field update strategy to constraints.ts** - Centralized `FIELD_UPDATE_STRATEGY` mapping fields to update types (download/update/filter/none) with helper functions
- **Add StateResolver.createSnapshot()** - Static method to create ChartStateSnapshot from resolved state, eliminating duplicate logic
- **Create useUpdateQueue composable** - Extract concurrent update handling, preventing race conditions
- **Simplify explorer.vue** - Replace inline logic with centralized utilities, simplify state watch

### Changes

| Layer | Before | After |
|-------|--------|-------|
| Field update logic | Inline in `handleUpdate()` | `FIELD_UPDATE_STRATEGY` in constraints.ts |
| Snapshot creation | `createSnapshotFromResolved()` in explorer.vue | `StateResolver.createSnapshot()` |
| Update queue | Variables in explorer.vue | `useUpdateQueue` composable |
| State change watch | 20+ manually listed dependencies | `getCurrentStateValues()` |

### Files Changed
- `app/lib/state/config/constraints.ts` - Add field update strategy
- `app/lib/state/config/index.ts` - Export new functions
- `app/lib/state/resolver/StateResolver.ts` - Add createSnapshot method
- `app/composables/useUpdateQueue.ts` - New composable
- `app/pages/explorer.vue` - Use new utilities
- `app/lib/state/config/constraints.test.ts` - Add tests
- `app/lib/state/resolver/StateResolver.test.ts` - Add tests

## Test plan
- [x] All 1584 tests pass (25 new tests added)
- [x] Lint passes
- [x] Type check passes
- [x] Build succeeds
- [x] Manual testing of explorer page functionality
- [x] Verify view transitions work correctly
- [x] Verify field changes trigger appropriate updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)