### PR TITLE
fix: ensure all explorer state changes flow through Resolution Flow

### DIFF
--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -421,10 +421,19 @@ useBrowserNavigation({
     'c', 't', 'ct', 'e', 'cs', 'df', 'dt', 'ss', 'bf', 'bt',
     'sp', 'ag', 'sb', 'bm', 'ce', 'st', 'pi', 'p', 'lg'
   ],
-  onNavigate: () => {
+  onNavigate: async () => {
     if (isInternalUrlUpdate.value) {
       return
     }
+    // Re-read state from URL and apply to refs before updating data
+    const { StateResolver } = await import('@/lib/state/resolver/StateResolver')
+    const route = useRoute()
+    const resolved = StateResolver.resolveInitial(route)
+    state.applyResolvedState(resolved)
+    state.setUserOverrides(resolved.userOverrides)
+    // Wait for Vue reactivity to propagate before updating chart
+    await nextTick()
+    // Now update data with correct state
     update('_countries')
   },
   isReady: isDataLoaded,


### PR DESCRIPTION
## Summary
- UI toggles and sliders were not properly updating state refs, causing values to "jump back"
- Refactored all handlers to use unified Resolution Flow pattern
- All state changes now consistently flow through StateResolver

## Changes
- Refactor `handleStateChange` to accept batch changes (for sliders with from/to)
- Add `handleUIStateChange` for UI-only changes (no data refresh needed)
- Fix 11 broken handlers:
  - `dateSliderChanged` / `baselineSliderChanged` (sliders)
  - `handleShowLabelsChanged` / `handleMaximizeChanged` / `handleShowLogarithmicChanged` (display)
  - `handleShowLogoChanged` / `handleShowQrCodeChanged` / `handleShowCaptionChanged` / `handleDecimalsChanged` (style)
- Remove redundant date range watcher

## Test plan
- [x] Toggle Log Scale - should persist and not jump back
- [x] Toggle Maximize - should persist and not jump back
- [x] Toggle Show Labels - should persist and not jump back
- [x] Drag date range slider - should not jump back after release
- [x] Drag baseline period slider - should not jump back after release
- [x] Toggle Show Logo/QR/Caption in Style tab - should persist
- [x] Verify URL updates correctly for all toggles
- [ ] Verify browser back/forward still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)