### PR TITLE
fix: trivial UI improvements

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -72,10 +72,6 @@ const items = computed(() => {
     label: 'Ranking',
     icon: 'i-lucide-chart-bar-decreasing',
     to: '/ranking'
-  }, {
-    label: 'Chart Gallery',
-    icon: 'i-lucide-gallery-horizontal-end',
-    to: '/charts'
   }]
 
   // Add "My Charts" if user is authenticated
@@ -86,6 +82,13 @@ const items = computed(() => {
       to: '/my-charts'
     })
   }
+
+  // Add Chart Gallery
+  navItems.push({
+    label: 'Chart Gallery',
+    icon: 'i-lucide-gallery-horizontal-end',
+    to: '/charts'
+  })
 
   // Add "Features" for non-pro users (PUBLIC and REGISTERED, tier < 2)
   if (tier.value < 2) {

--- a/app/components/charts/ChartCard.vue
+++ b/app/components/charts/ChartCard.vue
@@ -60,7 +60,7 @@
           <img
             :src="getThumbnailUrl()"
             :alt="chart.name"
-            class="w-full h-full object-cover hover:scale-105 transition-transform"
+            class="w-full h-full object-cover object-top hover:scale-105 transition-transform"
             loading="lazy"
           >
         </NuxtLink>

--- a/app/composables/useExplorerState.test.ts
+++ b/app/composables/useExplorerState.test.ts
@@ -389,10 +389,10 @@ describe('useExplorerState', () => {
   // ============================================================================
 
   describe('slider start', () => {
-    it('should default slider start to 2010', () => {
+    it('should default slider start to 2009', () => {
       const state = useExplorerState()
 
-      expect(state.sliderStart.value).toBe('2010')
+      expect(state.sliderStart.value).toBe('2009')
     })
 
     it('should update slider start', () => {

--- a/app/lib/state/config/constraints.test.ts
+++ b/app/lib/state/config/constraints.test.ts
@@ -55,7 +55,7 @@ describe('StateResolver Constraints', () => {
       expect(DEFAULT_VALUES.maximize).toBe(false)
       expect(DEFAULT_VALUES.showLogarithmic).toBe(false)
       expect(DEFAULT_VALUES.showLabels).toBe(true)
-      expect(DEFAULT_VALUES.sliderStart).toBe('2010')
+      expect(DEFAULT_VALUES.sliderStart).toBe('2009')
       expect(DEFAULT_VALUES.baselineMethod).toBe('mean')
     })
   })

--- a/app/lib/state/config/views.ts
+++ b/app/lib/state/config/views.ts
@@ -63,7 +63,7 @@ export const VIEWS: Record<ViewType, ViewConfig> = {
       // Date range (undefined = use data availability defaults)
       dateFrom: undefined as string | undefined,
       dateTo: undefined as string | undefined,
-      sliderStart: '2010',
+      sliderStart: '2009',
       baselineDateFrom: undefined as string | undefined,
       baselineDateTo: undefined as string | undefined,
 

--- a/app/lib/state/resolution/resolveChartState.test.ts
+++ b/app/lib/state/resolution/resolveChartState.test.ts
@@ -166,9 +166,9 @@ describe('resolveChartStateForRendering', () => {
       expect(state.dateTo).toBe('2024')
     })
 
-    it('should use default sliderStart of 2010', () => {
+    it('should use default sliderStart of 2009', () => {
       const state = resolveChartStateForRendering({ c: 'USA', ct: 'yearly' }, yearlyLabels)
-      expect(state.sliderStart).toBe('2010')
+      expect(state.sliderStart).toBe('2009')
     })
   })
 

--- a/app/lib/utils/chartTitles.ts
+++ b/app/lib/utils/chartTitles.ts
@@ -253,6 +253,7 @@ function getBaselineMethodDescription(method: string): string {
     case 'median':
       return 'median'
     case 'lm':
+    case 'lin_reg':
       return 'linear regression'
     default:
       return method


### PR DESCRIPTION
## Summary
- Reorder nav menu to show My Charts before Chart Gallery (more intuitive for users)
- Change default sliderStart to 2009 for full 10-year baseline support before pandemic
- Fix lin_reg baseline method translation in auto-generated descriptions
- Fix ranking screenshot cropping to show top of table instead of middle

## Test plan
- [x] Verify nav menu order shows My Charts before Chart Gallery
- [x] Verify explorer starts with 2009 as slider minimum
- [x] Save a chart with lin_reg baseline and verify description shows "linear regression"
- [x] View ranking charts in gallery and verify thumbnails show top of table

🤖 Generated with [Claude Code](https://claude.com/claude-code)