### PR TITLE
fix: improve duplicate chart handling and update save button state

### DIFF
--- a/app/composables/useSaveChart.test.ts
+++ b/app/composables/useSaveChart.test.ts
@@ -363,11 +363,8 @@ describe('useSaveChart', () => {
 
       await saveChart.saveToDB({ test: 'data' })
 
-      expect(showToast).toHaveBeenCalledWith(
-        'Chart saved and published!',
-        'success',
-        [{ label: 'View', to: '/charts/test-chart-slug' }]
-      )
+      // Same toast for public and private charts
+      expect(showToast).toHaveBeenCalledWith('Chart saved!', 'success')
     })
 
     it('should show toast without action for private chart', async () => {

--- a/app/composables/useSaveChart.ts
+++ b/app/composables/useSaveChart.ts
@@ -134,20 +134,11 @@ export function useSaveChart(options: SaveChartOptions) {
       // Close modal immediately
       showSaveModal.value = false
 
-      // Show success toast with view link for public charts
-      // Note: We don't auto-navigate since users might want to continue editing
-      if (saveChartPublic.value && response.chart?.slug) {
-        showToast(
-          `${entityName.charAt(0).toUpperCase() + entityName.slice(1)} saved and published!`,
-          'success',
-          [{ label: 'View', to: `/charts/${response.chart.slug}` }]
-        )
-      } else {
-        showToast(
-          `${entityName.charAt(0).toUpperCase() + entityName.slice(1)} saved!`,
-          'success'
-        )
-      }
+      // Show success toast
+      showToast(
+        `${entityName.charAt(0).toUpperCase() + entityName.slice(1)} saved!`,
+        'success'
+      )
     } catch (err: unknown) {
       console.error(`Failed to save ${entityName}:`, err)
 
@@ -164,9 +155,15 @@ export function useSaveChart(options: SaveChartOptions) {
       const hasDuplicateFlag = errorData?.duplicate === true
 
       if (is409 && hasDuplicateFlag) {
+        // Chart already exists - show duplicate warning in modal
         isDuplicate.value = true
         existingChart.value = errorData.existingChart || null
-        saveError.value = error.data?.message || error.message || 'You have already saved an identical chart'
+        // Update saved state so button shows "Saved!" with view link when modal is dismissed
+        isSaved.value = true
+        isModified.value = false
+        savedChartSlug.value = errorData.existingChart?.slug || null
+        savedChartId.value = errorData.existingChart?.id?.toString() || null
+        // Keep modal open so user can see the warning and use the links
       } else {
         saveError.value = err instanceof Error ? err.message : `Failed to save ${entityName}`
       }

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -528,9 +528,16 @@ const {
 } = chartActions
 
 // Wrap showSaveModal in computed for proper v-model binding
+// Reset duplicate state when modal opens
 const showSaveModal = computed({
   get: () => _showSaveModal.value,
   set: (val) => {
+    if (val) {
+      // Reset duplicate state when opening modal
+      isDuplicate.value = false
+      existingChart.value = null
+      saveError.value = ''
+    }
     _showSaveModal.value = val
   }
 })

--- a/app/toast.ts
+++ b/app/toast.ts
@@ -1,29 +1,6 @@
 import { useNuxtApp } from '#app'
 
-/**
- * Action button configuration for toast notifications.
- * Use either `to` for navigation or `onClick` for custom handlers.
- */
-export interface ToastAction {
-  /** Button label text */
-  label: string
-  /** Navigation target (route path) - use for link actions */
-  to?: string
-  /** Click handler function - use for custom actions */
-  onClick?: (e?: MouseEvent) => void
-  /** Optional icon */
-  icon?: string
-  /** Button color */
-  color?: 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
-  /** Button variant */
-  variant?: 'solid' | 'outline' | 'soft' | 'subtle' | 'ghost' | 'link'
-}
-
-export const showToast = (
-  message: string,
-  type: 'success' | 'error' | 'warning' | 'info' = 'info',
-  actions?: ToastAction[]
-) => {
+export const showToast = (message: string, type: 'success' | 'error' | 'warning' | 'info' = 'info') => {
   // Always log toasts to console for debugging
   const logPrefix = `[Toast:${type.toUpperCase()}]`
   if (type === 'error') {
@@ -49,16 +26,8 @@ export const showToast = (
     info: 'info'
   }
 
-  // Format actions with default button styling
-  const formattedActions = actions?.map(action => ({
-    ...action,
-    color: action.color || 'neutral',
-    variant: action.variant || 'outline'
-  }))
-
   toast.add({
     title: message,
-    color: colorMap[type] as 'success' | 'error' | 'warning' | 'info',
-    actions: formattedActions
+    color: colorMap[type] as 'success' | 'error' | 'warning' | 'info'
   })
 }


### PR DESCRIPTION
## Summary
- When a duplicate chart is detected, the save button now updates to show "Saved!" with "View saved chart" link
- Modal stays open to show duplicate warning with navigation links
- Duplicate state resets when modal opens (prevents stale warnings)
- Simplified toast (removed unsupported action buttons)

## Test plan
- [ ] Save a new chart → button shows "Saved!" with view link
- [ ] Try to save the same chart again → modal shows duplicate warning, button updates to "Saved!"
- [ ] Dismiss modal → button still shows "Saved!" with view link
- [ ] Modify chart → button changes to "Update Chart"
- [ ] Open modal again → duplicate warning is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)