### PR TITLE
fix: correctly save ranking chart state to database

### DIFF
--- a/server/api/charts/index.post.ts
+++ b/server/api/charts/index.post.ts
@@ -115,8 +115,28 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Convert state to query string and compute hash
-  const queryString = chartStateToQueryString(chartStateObj)
+  // Convert state to query string
+  // For ranking charts, the state object already uses URL parameter keys (a, p, j, etc.)
+  // For explorer charts, we need to convert field names to URL keys using chartStateToQueryString
+  let queryString: string
+  if (chartType === 'ranking') {
+    // Ranking: state already has URL keys, just convert to query string
+    const urlParams = new URLSearchParams()
+    for (const [key, value] of Object.entries(chartStateObj)) {
+      if (value !== undefined && value !== null) {
+        if (Array.isArray(value)) {
+          value.forEach(v => urlParams.append(key, String(v)))
+        } else {
+          urlParams.set(key, String(value))
+        }
+      }
+    }
+    queryString = urlParams.toString()
+  } else {
+    // Explorer: use chartStateToQueryString to convert field names to URL keys
+    queryString = chartStateToQueryString(chartStateObj)
+  }
+
   const params = queryStringToParams(queryString)
   const chartId = computeConfigHash(params)
 


### PR DESCRIPTION
Previously, when saving a ranking from the ranking page, the state was being incorrectly processed by chartStateToQueryString(), which expects explorer field names (countries, chartType, showPercentage, etc.) but was receiving ranking URL parameter keys (a, p, j, r, etc.).

This caused the ranking state to be lost or incorrectly converted, resulting in saved rankings that couldn't properly restore their configuration or displayed as explorer charts instead of ranking tables.

The fix:
- For ranking charts: directly convert the state object to a query string since it already uses URL parameter keys (a, p, j, df, dt, bm, etc.)
- For explorer charts: continue using chartStateToQueryString() to convert field names to URL keys

This ensures that:
1. Saved rankings preserve their full state (sort order, filters, etc.)
2. The "Remix This Chart" button redirects to /ranking (not /explorer)
3. Thumbnails use /ranking.png endpoint (not /chart.png)
4. The chartType field is correctly set to 'ranking' in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)