### PR TITLE
fix: skip excess calculation for periods before baseline start

### DIFF
--- a/app/components/explorer/ExplorerDataSelection.vue
+++ b/app/components/explorer/ExplorerDataSelection.vue
@@ -18,6 +18,8 @@ const props = defineProps<{
   sliderStart: string
   allYearlyChartLabelsUnique: string[]
   chartType: ChartType
+  /** Hide the "From" dropdown (used in excess/zscore views where range is fixed to baseline start) */
+  hideSliderStart?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -63,6 +65,7 @@ const emit = defineEmits<{
         :slider-value="props.sliderValue"
         :labels="props.labels"
         :chart-type="props.chartType"
+        :hide-slider-start="props.hideSliderStart"
         @update:slider-start="emit('sliderStartChanged', $event)"
         @slider-changed="emit('dateSliderChanged', $event)"
       />

--- a/app/components/shared/DateRangePicker.vue
+++ b/app/components/shared/DateRangePicker.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
   labels: string[]
   chartType: ChartType
   disabled?: boolean
+  /** Hide the "From" dropdown (used in excess/zscore views where range is fixed to baseline start) */
+  hideSliderStart?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -55,52 +57,66 @@ const availableYears = computed(() => {
     data-tour="date-range"
   >
     <div class="flex items-center gap-3">
-      <!-- From dropdown -->
-      <div class="flex items-center gap-2">
-        <label class="text-sm font-medium whitespace-nowrap">From</label>
-        <USelectMenu
-          :model-value="props.sliderStart"
-          :items="availableYears"
-          placeholder="Start"
-          size="sm"
-          class="w-24"
-          :disabled="props.disabled"
-          value-key="value"
-          @update:model-value="emit('update:sliderStart', $event)"
-        />
-        <UPopover>
-          <UButton
-            icon="i-lucide-info"
-            color="neutral"
-            variant="ghost"
-            size="xs"
-            aria-label="Start period information"
+      <!-- Info text for excess/zscore views (explains why slider starts at baseline) -->
+      <template v-if="props.hideSliderStart">
+        <div class="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+          <UIcon
+            name="i-lucide-info"
+            class="w-3.5 h-3.5 shrink-0"
           />
-          <template #content>
-            <div class="p-3 space-y-2 max-w-xs">
-              <div class="text-xs text-gray-700 dark:text-gray-300">
-                <template v-if="!hasExtendedTimeAccess">
-                  <div class="mb-2">
-                    {{ getUpgradeMessage('EXTENDED_TIME_PERIODS') }}
-                  </div>
-                  <NuxtLink
-                    :to="getFeatureUpgradeUrl('EXTENDED_TIME_PERIODS')"
-                    class="text-primary hover:underline font-medium"
-                  >
-                    {{ getFeatureUpgradeCTA('EXTENDED_TIME_PERIODS') }} →
-                  </NuxtLink>
-                </template>
-                <template v-else>
-                  Sets the earliest year in the available data range. The slider will start from this year.
-                </template>
-              </div>
-            </div>
-          </template>
-        </UPopover>
-      </div>
+          <span>Starts at baseline</span>
+        </div>
+        <div class="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+      </template>
 
-      <!-- Divider -->
-      <div class="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+      <!-- From dropdown (hidden in excess/zscore views) -->
+      <template v-if="!props.hideSliderStart">
+        <div class="flex items-center gap-2">
+          <label class="text-sm font-medium whitespace-nowrap">From</label>
+          <USelectMenu
+            :model-value="props.sliderStart"
+            :items="availableYears"
+            placeholder="Start"
+            size="sm"
+            class="w-24"
+            :disabled="props.disabled"
+            value-key="value"
+            @update:model-value="emit('update:sliderStart', $event)"
+          />
+          <UPopover>
+            <UButton
+              icon="i-lucide-info"
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              aria-label="Start period information"
+            />
+            <template #content>
+              <div class="p-3 space-y-2 max-w-xs">
+                <div class="text-xs text-gray-700 dark:text-gray-300">
+                  <template v-if="!hasExtendedTimeAccess">
+                    <div class="mb-2">
+                      {{ getUpgradeMessage('EXTENDED_TIME_PERIODS') }}
+                    </div>
+                    <NuxtLink
+                      :to="getFeatureUpgradeUrl('EXTENDED_TIME_PERIODS')"
+                      class="text-primary hover:underline font-medium"
+                    >
+                      {{ getFeatureUpgradeCTA('EXTENDED_TIME_PERIODS') }} →
+                    </NuxtLink>
+                  </template>
+                  <template v-else>
+                    Sets the earliest year in the available data range. The slider will start from this year.
+                  </template>
+                </div>
+              </div>
+            </template>
+          </UPopover>
+        </div>
+
+        <!-- Divider -->
+        <div class="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+      </template>
 
       <!-- Date Range Slider -->
       <div class="flex-1 flex items-center gap-2">

--- a/app/composables/useExplorerDataOrchestration.test.ts
+++ b/app/composables/useExplorerDataOrchestration.test.ts
@@ -84,7 +84,8 @@ vi.mock('./useDateRangeCalculations', () => ({
       effectiveMinDate: computed(() => {
         const labels = allLabels.value || []
         return labels.length > 0 ? labels[0] : null
-      })
+      }),
+      isBaselineRestrictedView: computed(() => false)
     }
   })
 }))

--- a/app/composables/useRankingData.test.ts
+++ b/app/composables/useRankingData.test.ts
@@ -109,7 +109,8 @@ vi.mock('./useDateRangeCalculations', () => ({
     findClosestYearLabel: vi.fn(() => null),
     matchDateToLabel: vi.fn(() => null),
     hasExtendedTimeAccess: computed(() => true),
-    effectiveMinDate: computed(() => null)
+    effectiveMinDate: computed(() => null),
+    isBaselineRestrictedView: computed(() => false)
   }))
 }))
 


### PR DESCRIPTION
## Summary
Fixes the explorer showing very large/incorrect excess percentage values for data points before the baseline period starts.

## Root Cause
The `calculateExcess` function was calculating excess for ALL periods, including those before the baseline. For pre-baseline periods, the baseline values are extrapolated and may be near-zero, causing division issues when calculating percentages.

## Changes
- Modified `calculateExcess` to accept `baselineStartIdx` parameter
- Skip excess calculation for periods before baseline start (set to `undefined`)
- Updated both call sites in `calculateBaseline` to pass the baseline start index

## Testing
- [ ] Explorer with excess view: periods before baseline should not show excess values
- [ ] Periods from baseline start onwards should show correct excess calculations
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)