### PR TITLE
fix: hide baseline subtitle during ranking page load

### DIFF
--- a/app/pages/ranking.vue
+++ b/app/pages/ranking.vue
@@ -274,10 +274,13 @@ const title = computed(() => {
 })
 
 const subtitle = computed(() => {
+  if (!baselineSliderValue.value[0] || !baselineSliderValue.value[1]) {
+    return ''
+  }
   return blDescription(
     selectedBaselineMethod.value || 'mean',
-    baselineSliderValue.value[0] || '',
-    baselineSliderValue.value[1] || ''
+    baselineSliderValue.value[0],
+    baselineSliderValue.value[1]
   )
 })
 


### PR DESCRIPTION
## Summary
Fixes the ranking page showing "Baseline: Average -" during initial load before baseline data is available.

## Changes
- Added guard in subtitle computed property to return empty string when baseline dates are not yet loaded

## Testing
- [ ] Manual verification: ranking page no longer shows partial baseline text during load

🤖 Generated with [Claude Code](https://claude.com/claude-code)