### PR TITLE
fix: apply label auto-hide logic in SSR chart rendering

### DIFF
--- a/server/routes/chart.png.ts
+++ b/server/routes/chart.png.ts
@@ -175,7 +175,8 @@ export default defineEventHandler(async (event) => {
             isDeathsType,
             isLE,
             isPopulationType,
-            chartUrl
+            chartUrl,
+            width
           )
 
           // Debug: Log chart config subtitle settings


### PR DESCRIPTION
## Summary
Fixes SSR chart rendering (chart.png) ignoring the label density auto-hide logic that the client uses.

## Root Cause
The client automatically hides data labels when there are too many data points (formula: hide if dataPoints > chartWidth/20). SSR was passing the raw `showLabels` setting without this density check, causing SSR charts to always show labels regardless of data density.

## Changes
- Import `shouldShowLabels` from labelVisibility module
- Calculate effective showLabels in `generateChartConfig` using the same auto-hide logic as client
- Use default SSR width (600px) for the calculation
- Apply effectiveShowLabels to matrix chart configs (bar/line charts don't support label toggling)

## Testing
- [ ] Weekly chart SSR: should NOT show labels (52 > 600/20 = 30)
- [ ] Yearly chart SSR with few years: should show labels
- [ ] Setting sl=0 in URL should still force hide labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)