### PR TITLE
fix: add missing h3 import and remove unused deprecated exports

### DIFF
--- a/app/lib/chart/index.ts
+++ b/app/lib/chart/index.ts
@@ -14,8 +14,6 @@ export { getChartLabels, blDescription } from './labels'
 
 // Filtering
 export {
-  getFilteredLabelAndData,
-  getFilteredChartData,
   getFilteredChartDataFromConfig,
   baselineMinRange
 } from './filtering'

--- a/server/utils/chartPngHelpers.ts
+++ b/server/utils/chartPngHelpers.ts
@@ -1,4 +1,4 @@
-import type { H3Event } from 'h3'
+import { type H3Event, getRequestHeader } from 'h3'
 import { dataLoader } from '../services/dataLoader'
 import type { AllChartData, CountryData } from '../../app/model'
 import { ChartPeriod, type ChartType } from '../../app/model/period'


### PR DESCRIPTION
## Summary

- Add missing `getRequestHeader` import from h3 in `chartPngHelpers.ts`
  - This fixes a potential runtime error in the `getClientIp` function which used `getRequestHeader` without importing it
- Remove unused deprecated exports from `chart/index.ts`:
  - `getFilteredLabelAndData` - internal function not used outside the module
  - `getFilteredChartData` - deprecated in favor of `getFilteredChartDataFromConfig`

## Test plan

- [x] TypeScript type checking passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] All 1651 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)