### PR TITLE
fix: preserve user state when switching views and enable z-score for all chart types

### DIFF
--- a/app/lib/state/config/views.ts
+++ b/app/lib/state/config/views.ts
@@ -241,7 +241,6 @@ export const VIEWS: Record<ViewType, ViewConfig> = {
     ],
 
     compatibleMetrics: ['cmr', 'asmr', 'deaths'], // All metrics that support baselines
-    compatibleChartStyles: ['line', 'bar'], // No matrix for z-scores
-    compatibleChartTypes: ['yearly', 'fluseason', 'midyear'] // Z-scores only available for yearly aggregations (s=1)
+    compatibleChartStyles: ['line', 'bar'] // No matrix for z-scores
   }
 }

--- a/app/lib/state/resolver/viewHelpers.test.ts
+++ b/app/lib/state/resolver/viewHelpers.test.ts
@@ -367,16 +367,13 @@ describe('viewHelpers', () => {
       expect(isChartTypeCompatible('monthly', 'mortality')).toBe(true)
     })
 
-    it('returns true for compatible chart types', () => {
+    it('returns true for all chart types in zscore view (no restrictions)', () => {
       expect(isChartTypeCompatible('yearly', 'zscore')).toBe(true)
       expect(isChartTypeCompatible('fluseason', 'zscore')).toBe(true)
       expect(isChartTypeCompatible('midyear', 'zscore')).toBe(true)
-    })
-
-    it('returns false for incompatible chart types', () => {
-      expect(isChartTypeCompatible('weekly', 'zscore')).toBe(false)
-      expect(isChartTypeCompatible('monthly', 'zscore')).toBe(false)
-      expect(isChartTypeCompatible('quarterly', 'zscore')).toBe(false)
+      expect(isChartTypeCompatible('weekly', 'zscore')).toBe(true)
+      expect(isChartTypeCompatible('monthly', 'zscore')).toBe(true)
+      expect(isChartTypeCompatible('quarterly', 'zscore')).toBe(true)
     })
   })
 })

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -325,19 +325,17 @@ const handleViewChanged = async (newView: ViewType) => {
   const router = useRouter()
   const route = useRoute()
 
-  // 1. Clear user overrides - when switching views, user wants the new view's defaults
-  state.clearUserOverrides()
-
-  // 2. Resolve view change through StateResolver
-  // This applies view defaults, constraints, and computes UI state
+  // 1. Resolve view change through StateResolver
+  // Keep user overrides - data selection settings (chartType, countries, dates) should persist
+  // View-specific display settings will use view defaults via resolveViewChange logic
   const { StateResolver } = await import('@/lib/state/resolver/StateResolver')
   const resolved = StateResolver.resolveViewChange(
     newView,
     state.getCurrentStateValues(),
-    new Set() // Pass empty set since we cleared overrides
+    state.getUserOverrides()
   )
 
-  // 2b. For excess/zscore views, adjust dateFrom to baseline start if needed
+  // 2. For excess/zscore views, adjust dateFrom to baseline start if needed
   // The visible date range is restricted to baseline start in these views
   if (newView === 'excess' || newView === 'zscore') {
     const baselineStart = dataOrchestration.baselineRange.value?.from


### PR DESCRIPTION
## Summary

- **Z-score now works with all chart types** (weekly, monthly, quarterly, etc.) - removed outdated restriction that limited it to yearly aggregations only
- **View switching preserves user data selection** - chartType, countries, dates no longer reset when switching between mortality/excess/zscore views

## Problem

1. When using z-score mode with weekly chart type and refreshing the page, it would fall back to "raw" mortality view
2. When switching views (e.g., mortality → zscore → excess), user-set values like `ct=weekly` would be forgotten

## Solution

1. Removed `compatibleChartTypes` restriction from zscore view config - the stats engine now supports z-score calculation for all time aggregations
2. Removed aggressive `clearUserOverrides()` call in `handleViewChanged` - now passes actual user overrides to StateResolver so data selection settings persist

## Test plan

- [ ] Set chart type to weekly, enable z-score, refresh page → should stay on z-score + weekly
- [ ] Set chart type to weekly, switch from mortality → zscore → mortality → should preserve weekly throughout
- [ ] Verify z-score calculations work correctly for weekly/monthly data

🤖 Generated with [Claude Code](https://claude.com/claude-code)