### PR TITLE
fix: add delete option to chart detail page and fix z-score save

### DIFF
--- a/app/composables/useExplorerChartActions.ts
+++ b/app/composables/useExplorerChartActions.ts
@@ -176,6 +176,7 @@ export function useExplorerChartActions(
       ageGroups: state.ageGroups.value,
       chartStyle: state.chartStyle.value,
       isExcess: state.isExcess.value,
+      isZScore: state.isZScore.value,
       showBaseline: state.showBaseline.value,
       baselineMethod: state.baselineMethod.value,
       baselineDateFrom: state.baselineDateFrom.value,


### PR DESCRIPTION
## Summary

- Add delete button to chart detail page (`/charts/[slug]`) for owners and admins
- Fix missing `isZScore` field when saving charts, which caused z-score charts to have different QR codes after saving

## Details

### Delete button
When viewing a saved chart, owners and admins can now delete the chart directly from the detail page. Previously this was only possible from the gallery/my-charts list views.

### Z-score save fix
When saving a z-score chart (with `zs=1` in URL), the `isZScore` field wasn't being included in the saved state. This caused:
- The saved chart config to be missing `zs=1`
- The QR code on the saved chart to be different from the original
- The hash `44136fa355b3` (hash of empty object `{}`) was being generated instead of the correct hash

## Test plan

- [ ] Save a z-score chart and verify the QR code matches the original
- [ ] View a saved chart as owner and verify delete button appears
- [ ] Delete a chart and verify redirect to gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)