### PR TITLE
fix: hide Sign Up button on mobile to prevent top bar overflow (closes #274)

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -225,9 +225,11 @@ const userMenuItems = computed<MenuItem[]>(() => {
           variant="ghost"
           label="Sign In"
         />
+        <!-- Hide Sign Up on mobile to prevent top bar overflow -->
         <UButton
           to="/signup"
           label="Sign Up"
+          class="hidden sm:inline-flex"
         />
       </template>
     </template>


### PR DESCRIPTION
## Summary

On mobile devices (iPhone), having both Sign In and Sign Up buttons in the header caused the viewport to overflow horizontally.

## Changes

- Hide Sign Up button on small screens (< 640px) using `hidden sm:inline-flex`
- Sign In button remains visible on all screen sizes
- Users can still access Sign Up through the Sign In page or mobile menu

## Testing

- [ ] Open site on mobile device or use browser dev tools to simulate mobile
- [ ] Verify top bar no longer overflows horizontally
- [ ] Verify Sign In button is visible
- [ ] Verify Sign Up button appears on larger screens (≥ 640px)

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)