### PR TITLE
fix: add mobile-specific chart sizing (closes #275, closes #276)

### DIFF
--- a/app/components/charts/MortalityChartControlsSecondary.vue
+++ b/app/components/charts/MortalityChartControlsSecondary.vue
@@ -7,6 +7,7 @@ import StyleTab from './controls/StyleTab.vue'
 import { CHART_PRESETS } from '@/lib/config/constants'
 import { chartStyles, baselineMethods, decimalPrecisions } from '@/model'
 import { useChartUIState } from '@/composables/useChartUIState'
+import { isMobile } from '@/utils'
 import type { ChartStyle } from '@/lib/chart/chartTypes'
 import type { ViewType } from '@/lib/state'
 
@@ -236,12 +237,18 @@ const showBaselineOption = computed(() =>
 )
 
 // Chart presets for dropdown
-const chartPresetOptions = CHART_PRESETS.map(preset => ({
-  name: preset.name,
-  value: preset.name,
-  label: preset.name,
-  category: preset.category
-}))
+// Filter out "Custom" on mobile since drag-to-resize doesn't work with touch
+const chartPresetOptions = computed(() => {
+  const presets = isMobile()
+    ? CHART_PRESETS.filter(p => p.name !== 'Custom')
+    : CHART_PRESETS
+  return presets.map(preset => ({
+    name: preset.name,
+    value: preset.name,
+    label: preset.name,
+    category: preset.category
+  }))
+})
 
 // Tab management
 const activeTab = ref('data')

--- a/app/components/explorer/ExplorerChartContainer.vue
+++ b/app/components/explorer/ExplorerChartContainer.vue
@@ -94,6 +94,31 @@ defineExpose({
   overflow: hidden;
 }
 
+/* Mobile-specific sizing: Use viewport-relative height for better mobile experience */
+@media (max-width: 639px) {
+  .chart-card {
+    aspect-ratio: unset;
+    height: 60vh; /* 60% of viewport height on mobile */
+    min-height: 300px;
+    max-height: 500px;
+  }
+
+  /* Ensure full height chain through UCard internal elements */
+  .chart-card :deep(> div) {
+    height: 100%;
+  }
+
+  .chart-wrapper {
+    height: 100%;
+  }
+
+  /* Make chart canvas fill the wrapper */
+  .chart-wrapper :deep(canvas) {
+    width: 100% !important;
+    height: 100% !important;
+  }
+}
+
 .chart-card :deep(.p-4) {
   padding: 0 !important;
 }

--- a/app/components/shared/DateRangePicker.vue
+++ b/app/components/shared/DateRangePicker.vue
@@ -56,7 +56,8 @@ const availableYears = computed(() => {
     class="w-full px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800/50"
     data-tour="date-range"
   >
-    <div class="flex items-center gap-3">
+    <!-- Mobile: stack vertically, Desktop: single row -->
+    <div class="flex flex-col sm:flex-row sm:items-center gap-3">
       <!-- Info text for excess/zscore views (explains why slider starts at baseline) -->
       <template v-if="props.hideSliderStart">
         <div class="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
@@ -66,7 +67,7 @@ const availableYears = computed(() => {
           />
           <span>Starts at baseline</span>
         </div>
-        <div class="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+        <div class="hidden sm:block h-6 w-px bg-gray-300 dark:bg-gray-600" />
       </template>
 
       <!-- From dropdown (hidden in excess/zscore views) -->
@@ -114,12 +115,12 @@ const availableYears = computed(() => {
           </UPopover>
         </div>
 
-        <!-- Divider -->
-        <div class="h-6 w-px bg-gray-300 dark:bg-gray-600" />
+        <!-- Divider - hidden on mobile -->
+        <div class="hidden sm:block h-6 w-px bg-gray-300 dark:bg-gray-600" />
       </template>
 
-      <!-- Date Range Slider -->
-      <div class="flex-1 flex items-center gap-2">
+      <!-- Date Range Slider - full width on mobile -->
+      <div class="flex-1 flex items-center gap-2 w-full sm:w-auto">
         <div class="flex-1">
           <DateSlider
             :slider-value="props.sliderValue"


### PR DESCRIPTION
## Summary

Charts were rendering with incorrect height on mobile devices, and the resize handle was not visible.

## Root Cause

Mobile devices don't receive the `.resizable` class (intentionally, to disable drag-to-resize). However, the responsive aspect ratio styles required this class:

```css
.chart-wrapper.resizable.auto-mode {
  aspect-ratio: 1 / 1; /* Mobile: square for vertical space */
}
```

Without `.resizable`, mobile fell back to the base `.chart-card` styles with a fixed `aspect-ratio: 16/10`, which resulted in a bad height.

## Fix

Added mobile-specific styles (< 640px breakpoint) that:
- Use `60vh` height (60% of viewport) for a viewport-relative size
- Set `min-height: 300px` and `max-height: 500px` for reasonable bounds
- Remove aspect-ratio constraint to allow viewport-relative sizing

## Note on Resize Handle (#276)

The resize handle is intentionally hidden on mobile since CSS `resize: both` doesn't work well with touch input. Users can still adjust chart size using the preset dropdown.

## Testing

- [ ] Open Explorer on mobile device or simulator
- [ ] Chart should render at a reasonable height (~60% of viewport)
- [ ] Chart should be scrollable if content exceeds visible area

Closes #275
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)