### PR TITLE
fix: linear regression trendline and sub-country jurisdictions (closes #282, closes #305)

### DIFF
--- a/app/lib/data/validation.test.ts
+++ b/app/lib/data/validation.test.ts
@@ -118,13 +118,22 @@ US,United States,2020-01-01,2023-12-31,3,0-100,cdc`
         expect(result.success).toBe(false)
       })
 
-      it('should reject invalid ISO3C code (too long)', async () => {
+      it('should reject invalid ISO3C code (too long, >6 chars)', async () => {
         const csv = `iso3c,jurisdiction,min_date,max_date,type,age_groups,source
-USA1,United States,2020-01-01,2023-12-31,3,0-100,cdc`
+USA-FLA,United States,2020-01-01,2023-12-31,3,0-100,cdc`
 
         const result = await validateMetadata(csv)
 
         expect(result.success).toBe(false)
+      })
+
+      it('should accept valid sub-country ISO3C code (6 chars)', async () => {
+        const csv = `iso3c,jurisdiction,min_date,max_date,type,age_groups,source
+USA-FL,USA - Florida,2020-01-01,2023-12-31,3,0-100,cdc`
+
+        const result = await validateMetadata(csv)
+
+        expect(result.success).toBe(true)
       })
 
       it('should reject empty jurisdiction', async () => {

--- a/app/lib/data/validation.ts
+++ b/app/lib/data/validation.ts
@@ -18,8 +18,8 @@ const log = logger.withPrefix('Validation')
  * Validates the structure of country metadata records from CSV files.
  * Each field is required and must match the expected format.
  *
- * @property {string} iso3c - Three-letter country code (e.g., "USA", "GBR")
- * @property {string} jurisdiction - Country/region name (e.g., "United States")
+ * @property {string} iso3c - Country/jurisdiction code (e.g., "USA", "GBR", "USA-FL", "DEU-SN")
+ * @property {string} jurisdiction - Country/region name (e.g., "United States", "USA - Florida")
  * @property {string} min_date - Earliest available data date
  * @property {string} max_date - Latest available data date
  * @property {string} type - Data type indicator
@@ -27,7 +27,8 @@ const log = logger.withPrefix('Validation')
  * @property {string} source - Data source identifier
  */
 const CountryRawSchema = z.object({
-  iso3c: z.string().min(3).max(3),
+  // Allow 3-letter codes (USA, DEU) or hyphenated sub-country codes (USA-FL, DEU-SN, CAN-ON)
+  iso3c: z.string().min(3).max(6),
   jurisdiction: z.string().min(1),
   min_date: z.string(),
   max_date: z.string(),
@@ -47,7 +48,7 @@ const CountryRawSchema = z.object({
  * ASMR fields - only the aggregate files have them. Therefore ASMR fields
  * are optional in this schema.
  *
- * @property {string} iso3c - Three-letter country code
+ * @property {string} iso3c - Country/jurisdiction code (e.g., "USA", "USA-FL", "DEU-SN")
  * @property {string} population - Population count (as string)
  * @property {string} date - Date/period of the data record
  * @property {string} type - Data type indicator
@@ -61,7 +62,8 @@ const CountryRawSchema = z.object({
  * @property {string} [asmr_country] - Age-standardized mortality rate (country-specific, optional)
  */
 const CountryDataRawSchema = z.object({
-  iso3c: z.string().min(3).max(3),
+  // Allow 3-letter codes (USA, DEU) or hyphenated sub-country codes (USA-FL, DEU-SN, CAN-ON)
+  iso3c: z.string().min(3).max(6),
   population: z.string(),
   date: z.string(),
   type: z.string(),


### PR DESCRIPTION
## Summary
- Fix linear regression trendline appearing curved instead of as a straight line (#282)
- Show all jurisdictions (countries + states/provinces) by default on ranking page (#305)

## Changes
1. **Linear regression fix** (`app/lib/data/baselines.ts`): Set seasonality parameter to 1 when using linear regression method, preventing the stats API from applying seasonal decomposition which was causing the curved line.

2. **Jurisdictions fix** (`app/composables/useRankingState.ts`): Changed default `jurisdictionType` from `'countries'` to `'countries_states'` so users can compare any jurisdiction (e.g., Florida vs Germany, Alberta vs Texas) without changing filters.

## Test plan
- [ ] Verify linear regression trendline displays as a straight line on charts
- [ ] Verify ranking page shows US states, German states, and Canadian provinces by default
- [ ] Verify users can still filter to specific jurisdiction types using the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)