### PR TITLE
fix: round baseline API data to avoid floating point artifacts

### DIFF
--- a/app/lib/config/constants.ts
+++ b/app/lib/config/constants.ts
@@ -11,6 +11,12 @@ import { getWindow } from '../utils/dom'
 // =============================================================================
 
 /**
+ * Decimal precision for baseline API data values
+ * Prevents floating point artifacts (e.g., 82.15455999999999 -> 82.1546)
+ */
+export const BASELINE_DATA_PRECISION = 4
+
+/**
  * Default baseline year for mortality data comparisons
  * For yearly charts: 2017, 2018, 2019
  * For fluseason/midyear charts: 2016/17, 2017/18, 2018/19 (starts at 2016)

--- a/app/lib/data/baselines.ts
+++ b/app/lib/data/baselines.ts
@@ -5,7 +5,7 @@ import type {
   DataVector
 } from '@/model'
 import { dataLoader } from '../dataLoader'
-import { getMaxBaselinePeriod, EXTERNAL_SERVICES } from '../config/constants'
+import { getMaxBaselinePeriod, EXTERNAL_SERVICES, BASELINE_DATA_PRECISION } from '../config/constants'
 import { logger } from '../logger'
 
 /**
@@ -232,7 +232,10 @@ const calculateBaseline = async (
     // Only send data from baseline start onwards to reduce payload size
     // This significantly reduces the URL length and server processing time
     const trimmed_data = all_data.slice(baselineStartIdx)
-    const dataParam = (trimmed_data as (string | number)[]).join(',')
+    // Round numbers to avoid floating point precision issues (e.g., 82.15455999999999 -> 82.1546)
+    const dataParam = (trimmed_data as (string | number)[])
+      .map(v => typeof v === 'number' ? Number(v.toFixed(BASELINE_DATA_PRECISION)) : v)
+      .join(',')
 
     // Adjust bs/be to be relative to trimmed data (1-indexed)
     // Since we start from baselineStartIdx, baseline now starts at index 1

--- a/server/utils/baselines.ts
+++ b/server/utils/baselines.ts
@@ -12,7 +12,7 @@ import type {
   DataVector
 } from '../../app/model'
 import { fetchBaselineWithCircuitBreaker } from './baselineApi'
-import { EXTERNAL_SERVICES } from '../../app/lib/config/constants'
+import { EXTERNAL_SERVICES, BASELINE_DATA_PRECISION } from '../../app/lib/config/constants'
 import { logger } from '../../app/lib/logger'
 
 // Default stats API URL - can be overridden via NUXT_PUBLIC_STATS_URL
@@ -144,7 +144,10 @@ const calculateBaseline = async (
     const baseUrl = statsUrl || DEFAULT_STATS_URL
     // Send full dataset with bs/be params to specify baseline range
     // API uses 1-indexed values, so add 1 to our 0-indexed values
-    const dataParam = (all_data as (string | number)[]).join(',')
+    // Round numbers to avoid floating point precision issues (e.g., 82.15455999999999 -> 82.1546)
+    const dataParam = (all_data as (string | number)[])
+      .map(v => typeof v === 'number' ? Number(v.toFixed(BASELINE_DATA_PRECISION)) : v)
+      .join(',')
     const bs = baselineStartIdx + 1 // Convert to 1-indexed
     const be = baselineEndIdx + 1 // Convert to 1-indexed
     // With bs/be, PI is calculated for all post-be periods - no h needed


### PR DESCRIPTION
## Summary
- Round numeric values to 4 decimal places before sending to stats API
- Prevents JavaScript floating point precision issues (e.g., `82.15455999999999` → `82.1546`)

## Changes
- Added `BASELINE_DATA_PRECISION` constant to `app/lib/config/constants.ts`
- Updated client-side `app/lib/data/baselines.ts` to use rounding
- Updated server-side `server/utils/baselines.ts` to use rounding

## Test plan
- [ ] Verify baseline API URLs no longer contain long floating point numbers
- [ ] Verify baseline calculations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)