### PR TITLE
fix: skip auto-start tutorial for authenticated users

### DIFF
--- a/app/composables/useTutorial.ts
+++ b/app/composables/useTutorial.ts
@@ -261,9 +261,11 @@ export function useTutorial() {
 
   /**
    * Auto-start tutorial on first visit (call this in onMounted)
+   * Never auto-starts for authenticated users - they already know the interface
    */
   const autoStartTutorial = (pageType: 'explorer' | 'ranking' = 'explorer'): void => {
-    if (import.meta.client && !hasCompletedTutorial(pageType)) {
+    // Never auto-start tutorial for logged-in users (Issue #320)
+    if (import.meta.client && !isAuthenticated.value && !hasCompletedTutorial(pageType)) {
       // Add a delay to ensure DOM is ready and elements are visible
       // Ranking page needs more time since data needs to load first (v-if="hasLoaded")
       const delay = pageType === 'ranking' ? 2000 : 1000


### PR DESCRIPTION
## Summary
- Tutorial no longer auto-starts for logged-in users on Explorer and Ranking pages
- Authenticated users already know the interface, so showing the tutorial creates a disruptive experience
- Manual help button (?) in header still allows users to restart the tutorial if they want a refresher

Fixes #320

## Test plan
- [ ] Visit /explorer as unauthenticated user → tutorial should auto-start
- [ ] Visit /ranking as unauthenticated user → tutorial should auto-start  
- [ ] Log in, visit /explorer → tutorial should NOT auto-start
- [ ] Log in, visit /ranking → tutorial should NOT auto-start
- [ ] While logged in, click help (?) button → tutorial should still work manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)