### PR TITLE
fix: add Twitter-specific meta tags for social media preview images

### DIFF
--- a/app/pages/charts/[slug].vue
+++ b/app/pages/charts/[slug].vue
@@ -425,6 +425,9 @@ useSeoMeta({
   ogTitle: () => chart.value?.name || 'Chart',
   ogDescription: () => chart.value?.description || 'Mortality data visualization',
   ogImage: absoluteChartImageUrl,
-  twitterCard: 'summary_large_image'
+  twitterCard: 'summary_large_image',
+  twitterImage: absoluteChartImageUrl,
+  twitterTitle: () => chart.value?.name || 'Chart',
+  twitterDescription: () => chart.value?.description || 'Mortality data visualization'
 })
 </script>

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -57,8 +57,13 @@ const { ogImageUrl, ogTitle, ogDescription } = useChartOgImage(chartState)
 useSeoMeta({
   title: ogTitle,
   description: ogDescription,
+  ogTitle: ogTitle,
+  ogDescription: ogDescription,
   ogImage: ogImageUrl,
-  twitterCard: 'summary_large_image'
+  twitterCard: 'summary_large_image',
+  twitterImage: ogImageUrl,
+  twitterTitle: ogTitle,
+  twitterDescription: ogDescription
 })
 
 // Type predicates and computed helpers based on state

--- a/app/pages/ranking.vue
+++ b/app/pages/ranking.vue
@@ -50,10 +50,24 @@ const { isAuthenticated } = useAuth()
 // Tutorial for first-time users
 const { autoStartTutorial } = useTutorial()
 
-// Set page title
+// Set page meta (note: ranking page is CSR-only, so OG tags won't be seen by crawlers)
+// Static fallback values are used since dynamic state isn't available during SSR
+const rankingTitle = 'Excess Mortality Ranking - Mortality Watch'
+const rankingDescription = 'Compare excess mortality rates across countries and regions. Interactive ranking table with customizable time periods and metrics.'
+const config = useRuntimeConfig()
+const siteUrl = config.public.siteUrl || 'https://www.mortality.watch'
+const rankingOgImage = `${siteUrl}/ranking.png`
+
 useSeoMeta({
-  title: 'Excess Mortality Ranking - Mortality Watch',
-  description: 'Compare excess mortality rates across countries and regions. Interactive ranking table with customizable time periods and metrics.'
+  title: rankingTitle,
+  description: rankingDescription,
+  ogTitle: rankingTitle,
+  ogDescription: rankingDescription,
+  ogImage: rankingOgImage,
+  twitterCard: 'summary_large_image',
+  twitterImage: rankingOgImage,
+  twitterTitle: rankingTitle,
+  twitterDescription: rankingDescription
 })
 
 // ============================================================================


### PR DESCRIPTION
Added twitterImage, twitterTitle, and twitterDescription meta tags to explorer and chart detail pages. Twitter/X specifically looks for these tags when generating preview cards, not just Open Graph tags.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)