### PR TITLE
feat: default maximize to true when cumulative is enabled

### DIFF
--- a/app/lib/state/config/constraints.test.ts
+++ b/app/lib/state/config/constraints.test.ts
@@ -211,6 +211,20 @@ describe('StateResolver Constraints', () => {
     })
   })
 
+  describe('Cumulative On Constraints', () => {
+    it('should default maximize to true when cumulative is on (soft constraint)', () => {
+      const state = { cumulative: true }
+      const constraint = STATE_CONSTRAINTS.find(
+        c => c.when(state) && c.apply.maximize === true
+      )
+
+      expect(constraint).toBeDefined()
+      expect(constraint?.apply.maximize).toBe(true)
+      expect(constraint?.allowUserOverride).toBe(true) // soft constraint - user can override
+      expect(constraint?.priority).toBe(0) // lowest priority
+    })
+  })
+
   describe('Priority Levels', () => {
     it('should have hard constraints with priority 2', () => {
       const hardConstraints = STATE_CONSTRAINTS.filter(c => c.priority === 2)
@@ -230,9 +244,14 @@ describe('StateResolver Constraints', () => {
       })
     })
 
-    // NOTE: Test for priority 0 (soft defaults) removed
-    // All priority 0 constraints were excess-related and moved to view system
-    // If we add new priority 0 constraints in the future, they should allow user override
+    it('should have soft default constraints with priority 0', () => {
+      const softConstraints = STATE_CONSTRAINTS.filter(c => c.priority === 0)
+
+      expect(softConstraints.length).toBeGreaterThan(0)
+      softConstraints.forEach((constraint) => {
+        expect(constraint.allowUserOverride).toBe(true) // soft defaults can be overridden
+      })
+    })
 
     it('should sort constraints by priority (high to low)', () => {
       const sorted = [...STATE_CONSTRAINTS].sort((a, b) => {

--- a/app/lib/state/config/constraints.ts
+++ b/app/lib/state/config/constraints.ts
@@ -232,6 +232,21 @@ const cumulativeOffConstraints: StateConstraint = {
 }
 
 /**
+ * Cumulative ON constraints
+ * When cumulative is enabled, default maximize to true for better visualization
+ * of cumulative data ranges. User can still disable maximize if desired.
+ */
+const cumulativeOnConstraints: StateConstraint = {
+  when: state => state.cumulative === true,
+  apply: {
+    maximize: true
+  },
+  reason: 'Default to maximize for better cumulative data visualization',
+  allowUserOverride: true,
+  priority: 0 // Lowest priority - only acts as fallback default
+}
+
+/**
  * View synchronization constraints
  * Synchronize isExcess and isZScore flags with the view field
  */
@@ -294,5 +309,6 @@ export const STATE_CONSTRAINTS: StateConstraint[] = [
   cumulativeOffConstraints,
 
   // Priority 0: Soft defaults (lowest priority, allow user override)
-  baselineOnRestorePI
+  baselineOnRestorePI,
+  cumulativeOnConstraints
 ]


### PR DESCRIPTION
## Summary
- When cumulative mode is enabled, the maximize toggle now defaults to true
- This provides better visualization of cumulative data ranges which often vary significantly
- Implemented as a soft constraint (priority 0) so users can still manually disable maximize if preferred

Fixes #317

## Test plan
- [ ] Go to Explorer page with excess view enabled
- [ ] Enable cumulative toggle → maximize should auto-enable
- [ ] Disable maximize manually → should stay disabled (user override respected)
- [ ] Disable cumulative → maximize returns to default (false)
- [ ] Re-enable cumulative → maximize auto-enables again

🤖 Generated with [Claude Code](https://claude.com/claude-code)