### PR TITLE
fix: increase chart right padding when data labels are enabled

### DIFF
--- a/app/lib/chart/chartConfig.test.ts
+++ b/app/lib/chart/chartConfig.test.ts
@@ -114,8 +114,20 @@ describe('chartConfig', () => {
         expect(config.options.maintainAspectRatio).toBe(false)
       })
 
-      it('should configure layout padding', () => {
-        const data = createMockChartData()
+      it('should configure layout padding with extra right padding when labels are shown', () => {
+        const data = createMockChartData() // showLabels: true by default
+        const config = makeBarLineChartConfig(data, false, false, false, false, false)
+
+        expect(config.options.layout.padding).toEqual({
+          top: 10,
+          right: 20, // Extra padding to prevent label cutoff
+          bottom: 10,
+          left: 10
+        })
+      })
+
+      it('should configure layout padding with standard right padding when labels are hidden', () => {
+        const data = createMockChartData({ showLabels: false })
         const config = makeBarLineChartConfig(data, false, false, false, false, false)
 
         expect(config.options.layout.padding).toEqual({

--- a/app/lib/chart/chartConfig.ts
+++ b/app/lib/chart/chartConfig.ts
@@ -187,6 +187,9 @@ export const makeBarLineChartConfig = (
   // Logo and QR code plugins overlay the chart, so no padding needed for them
   // They draw at absolute positions in corners without affecting chart layout
 
+  // Increase right padding when data labels are enabled to prevent cutoff
+  const rightPadding = data.showLabels ? 20 : 10
+
   return {
     plugins: [createBackgroundPlugin(isDark)],
     options: {
@@ -196,7 +199,7 @@ export const makeBarLineChartConfig = (
       layout: {
         padding: {
           top: 10,
-          right: 10,
+          right: rightPadding,
           bottom: 10,
           left: 10
         }

--- a/server/utils/auth.test.ts
+++ b/server/utils/auth.test.ts
@@ -81,6 +81,11 @@ vi.mock('#db', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ field, value }))
 }))
 
+// Mock inviteCode module to prevent database access
+vi.mock('./inviteCode', () => ({
+  checkAndExpireTrialSubscription: vi.fn(async () => false)
+}))
+
 describe('Auth Utilities', () => {
   let originalEnv: NodeJS.ProcessEnv
 


### PR DESCRIPTION
Labels were being cutoff on the right side of charts when datalabels were displayed. Increased right padding from 10px to 20px when showLabels is true.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)