### PR TITLE
fix: include all chart state fields when saving (userColors, sliderSt…

### DIFF
--- a/app/composables/useExplorerChartActions.ts
+++ b/app/composables/useExplorerChartActions.ts
@@ -190,7 +190,14 @@ export function useExplorerChartActions(
       standardPopulation: state.standardPopulation.value,
       showLogarithmic: state.showLogarithmic.value,
       maximize: state.maximize.value,
-      showLabels: state.showLabels.value
+      showLabels: state.showLabels.value,
+      userColors: state.userColors.value,
+      sliderStart: state.sliderStart.value,
+      decimals: state.decimals.value,
+      showLogo: state.showLogo.value,
+      showQrCode: state.showQrCode.value,
+      showCaption: state.showCaption.value,
+      showTitle: state.showTitle.value
     }
 
     await saveToDBComposable(chartStateData)

--- a/server/utils/chartPngHelpers.ts
+++ b/server/utils/chartPngHelpers.ts
@@ -238,7 +238,11 @@ export async function transformChartData(
   chartUrl: string,
   _isAsmrType: boolean
 ) {
-  const colors = getChartColors()
+  // Use user-defined colors if provided, otherwise fall back to default theme colors
+  const defaultColors = getChartColors(state.darkMode)
+  const colors = state.userColors && state.userColors.length > 0
+    ? [...state.userColors, ...defaultColors.slice(state.userColors.length)]
+    : defaultColors
 
   // Use the unified toChartFilterConfig - same function as client
   const config = toChartFilterConfig(state, allCountries, colors, chartUrl)


### PR DESCRIPTION
…art, etc.)

The saveToDB function was missing several state fields that should be persisted:
- userColors (custom chart colors)
- sliderStart (slider start position)
- decimals (decimal precision)
- showLogo, showQrCode, showCaption, showTitle (chart appearance options)

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)