### PR TITLE
fix: OG images, tier enforcement, error messages, and auth redirects

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -10,6 +10,7 @@ interface MenuItem {
 const { isIncognito } = useIncognitoMode()
 const { isAuthenticated, user, tier } = useAuth()
 const { startTutorial } = useTutorial()
+const { loginUrl, signupUrl } = useAuthRedirect()
 const colorMode = useColorMode()
 
 // Color mode toggle - cycles through light -> dark -> system
@@ -221,13 +222,13 @@ const userMenuItems = computed<MenuItem[]>(() => {
       </template>
       <template v-else>
         <UButton
-          to="/login"
+          :to="loginUrl"
           variant="ghost"
           label="Sign In"
         />
         <!-- Hide Sign Up on mobile to prevent top bar overflow -->
         <UButton
-          to="/signup"
+          :to="signupUrl"
           label="Sign Up"
           class="hidden sm:inline-flex"
         />

--- a/app/components/UpgradeCard.vue
+++ b/app/components/UpgradeCard.vue
@@ -112,7 +112,7 @@
         <!-- CTA -->
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
           <UButton
-            to="/signup"
+            :to="signupUrl"
             color="primary"
             size="xl"
           >
@@ -316,4 +316,5 @@
 <script setup lang="ts">
 // Get user from auth composable
 const { user } = useAuth()
+const { signupUrl } = useAuthRedirect()
 </script>

--- a/app/components/charts/ChartActions.vue
+++ b/app/components/charts/ChartActions.vue
@@ -2,6 +2,7 @@
 // Feature access for data export
 const { can } = useFeatureAccess()
 const canExportData = computed(() => can('EXPORT_DATA'))
+const { goToSignup } = useAuthRedirect()
 
 const props = withDefaults(defineProps<{
   showSaveButton?: boolean
@@ -153,7 +154,7 @@ const emit = defineEmits<{
           <!-- CSV Export -->
           <button
             :class="canExportData ? 'chart-option-button' : 'chart-option-button opacity-60'"
-            @click="canExportData ? emit('exportCSV') : navigateTo('/signup')"
+            @click="canExportData ? emit('exportCSV') : goToSignup()"
           >
             <UIcon
               name="i-lucide-file-spreadsheet"
@@ -182,7 +183,7 @@ const emit = defineEmits<{
           <!-- JSON Export -->
           <button
             :class="canExportData ? 'chart-option-button' : 'chart-option-button opacity-60'"
-            @click="canExportData ? emit('exportJSON') : navigateTo('/signup')"
+            @click="canExportData ? emit('exportJSON') : goToSignup()"
           >
             <UIcon
               name="i-lucide-braces"

--- a/app/components/charts/MortalityChart.vue
+++ b/app/components/charts/MortalityChart.vue
@@ -91,6 +91,9 @@ const Matrix = createTypedChart('matrix', MatrixController)
 // Get color mode for theme reactivity
 const colorMode = useColorMode()
 
+// Get user tier for feature gating (logo/QR visibility)
+const { tier } = useAuth()
+
 // Track chart width for auto-hide label logic
 const chartWidth = ref<number>(800)
 
@@ -122,7 +125,7 @@ const lineConfig = computed(() => {
     props.showLogo,
     props.decimals,
     isDark,
-    undefined, // userTier
+    tier.value, // userTier: enforce logo/QR visibility based on viewer's tier
     props.showCaption,
     props.showTitle,
     false, // isSSR
@@ -145,7 +148,7 @@ const barConfig = computed(() => {
     props.showLogo,
     props.decimals,
     isDark,
-    undefined, // userTier
+    tier.value, // userTier: enforce logo/QR visibility based on viewer's tier
     props.showCaption,
     props.showTitle,
     false, // isSSR
@@ -170,7 +173,7 @@ const matrixConfig = computed(() => {
     props.showLogo,
     isDark,
     props.decimals,
-    undefined, // userTier
+    tier.value, // userTier: enforce logo/QR visibility based on viewer's tier
     props.showCaption,
     props.showTitle
   ) as unknown as ChartJSConfig<'matrix', MatrixDataPoint[]>

--- a/app/composables/useAuthRedirect.ts
+++ b/app/composables/useAuthRedirect.ts
@@ -1,0 +1,64 @@
+/**
+ * Composable for handling auth redirects
+ *
+ * Provides URLs to login/signup pages that include the current page as a
+ * redirect parameter, so users return to their original location after auth.
+ */
+export function useAuthRedirect() {
+  const route = useRoute()
+
+  /**
+   * Get login URL with current page as redirect
+   * Excludes auth pages from redirect to avoid loops
+   */
+  const loginUrl = computed(() => {
+    const currentPath = route.fullPath
+    // Don't redirect back to auth pages
+    const authPages = ['/login', '/signup', '/forgot-password', '/reset-password', '/check-email', '/verify-email']
+    const isAuthPage = authPages.some(page => currentPath.startsWith(page))
+
+    if (isAuthPage || currentPath === '/') {
+      return '/login'
+    }
+
+    return `/login?redirect=${encodeURIComponent(currentPath)}`
+  })
+
+  /**
+   * Get signup URL with current page as redirect
+   * Excludes auth pages from redirect to avoid loops
+   */
+  const signupUrl = computed(() => {
+    const currentPath = route.fullPath
+    // Don't redirect back to auth pages
+    const authPages = ['/login', '/signup', '/forgot-password', '/reset-password', '/check-email', '/verify-email']
+    const isAuthPage = authPages.some(page => currentPath.startsWith(page))
+
+    if (isAuthPage || currentPath === '/') {
+      return '/signup'
+    }
+
+    return `/signup?redirect=${encodeURIComponent(currentPath)}`
+  })
+
+  /**
+   * Navigate to login with redirect
+   */
+  function goToLogin() {
+    return navigateTo(loginUrl.value)
+  }
+
+  /**
+   * Navigate to signup with redirect
+   */
+  function goToSignup() {
+    return navigateTo(signupUrl.value)
+  }
+
+  return {
+    loginUrl,
+    signupUrl,
+    goToLogin,
+    goToSignup
+  }
+}

--- a/app/composables/useChartOgImage.ts
+++ b/app/composables/useChartOgImage.ts
@@ -18,7 +18,8 @@ export function useChartOgImage(state: MaybeRef<Partial<ChartState>>) {
 
   const ogImageUrl = computed(() => {
     const currentState = unref(state)
-    const queryString = chartStateToQueryString(currentState)
+    // Include defaults so OG images always have complete state
+    const queryString = chartStateToQueryString(currentState, true)
 
     // Generate chart.png URL with state
     return `${siteUrl}/chart.png?${queryString}`

--- a/app/lib/chartState.ts
+++ b/app/lib/chartState.ts
@@ -113,24 +113,29 @@ export function decodeChartState(query: Record<string, string | string[]>): Char
 
 /**
  * Encode chart state to query parameters
+ * @param state - Chart state to encode
+ * @param includeDefaults - If true, include values even if they match defaults (useful for OG images)
  */
-export function encodeChartState(state: Partial<ChartState>): Record<string, string | string[]> {
+export function encodeChartState(state: Partial<ChartState>, includeDefaults: boolean = false): Record<string, string | string[]> {
   const query: Record<string, string | string[]> = {}
 
   for (const [field, config] of Object.entries(stateFieldEncoders)) {
     const value = state[field as keyof ChartState]
     const defaultValue = Defaults[field as keyof typeof Defaults]
 
-    // Skip if value is undefined or matches default
+    // Skip if value is undefined
     if (value === undefined) continue
 
-    // Deep equality check for arrays
-    if (Array.isArray(value) && Array.isArray(defaultValue)) {
-      if (value.length === defaultValue.length && value.every((v, i) => v === defaultValue[i])) {
+    // Skip values that match defaults (unless includeDefaults is true)
+    if (!includeDefaults) {
+      // Deep equality check for arrays
+      if (Array.isArray(value) && Array.isArray(defaultValue)) {
+        if (value.length === defaultValue.length && value.every((v, i) => v === defaultValue[i])) {
+          continue
+        }
+      } else if (value === defaultValue) {
         continue
       }
-    } else if (value === defaultValue) {
-      continue
     }
 
     const key = config.key
@@ -155,9 +160,11 @@ export function encodeChartState(state: Partial<ChartState>): Record<string, str
 
 /**
  * Convert chart state to URL query string
+ * @param state - Chart state to encode
+ * @param includeDefaults - If true, include values even if they match defaults (useful for OG images)
  */
-export function chartStateToQueryString(state: Partial<ChartState>): string {
-  const query = encodeChartState(state)
+export function chartStateToQueryString(state: Partial<ChartState>, includeDefaults: boolean = false): string {
+  const query = encodeChartState(state, includeDefaults)
   const params = new URLSearchParams()
 
   for (const [key, value] of Object.entries(query)) {

--- a/app/pages/charts/[slug].vue
+++ b/app/pages/charts/[slug].vue
@@ -427,9 +427,9 @@ useSeoMeta({
   description: () => chart.value?.description || 'Mortality data visualization',
   ogTitle: () => chart.value?.name || 'Chart',
   ogDescription: () => chart.value?.description || 'Mortality data visualization',
-  ogImage: absoluteChartImageUrl,
+  ogImage: () => absoluteChartImageUrl.value,
   twitterCard: 'summary_large_image',
-  twitterImage: absoluteChartImageUrl,
+  twitterImage: () => absoluteChartImageUrl.value,
   twitterTitle: () => chart.value?.name || 'Chart',
   twitterDescription: () => chart.value?.description || 'Mortality data visualization'
 })

--- a/app/pages/check-email.vue
+++ b/app/pages/check-email.vue
@@ -19,6 +19,12 @@ const rawEmail = route.query.email as string || ''
 const emailValidation = z.string().email().safeParse(rawEmail)
 const email = emailValidation.success ? rawEmail : ''
 
+// Preserve redirect URL for login link
+const redirectUrl = computed(() => route.query.redirect as string || '')
+const loginUrlWithRedirect = computed(() =>
+  redirectUrl.value ? `/login?redirect=${encodeURIComponent(redirectUrl.value)}` : '/login'
+)
+
 async function resendVerification(): Promise<void> {
   if (!email) {
     toast.add({
@@ -160,7 +166,7 @@ async function resendVerification(): Promise<void> {
 
       <div class="pt-4 border-t border-default">
         <ULink
-          to="/login"
+          :to="loginUrlWithRedirect"
           class="text-sm text-primary hover:underline"
         >
           Back to Login

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -33,6 +33,7 @@ import { computeConfigHash, extractUrlParams } from '@/lib/shortUrl/hashConfig'
 
 // Auth state for conditional features
 const { isAuthenticated } = useAuth()
+const { goToSignup } = useAuthRedirect()
 
 // Tutorial for first-time users
 const { autoStartTutorial } = useTutorial()
@@ -768,7 +769,7 @@ watch(
             @copy-link="copyChartLink"
             @download-chart="downloadChart"
             @screenshot="screenshotChart"
-            @save-chart="navigateTo('/signup')"
+            @save-chart="goToSignup"
             @export-c-s-v="exportCSV"
             @export-j-s-o-n="exportJSON"
           >

--- a/app/pages/ranking.vue
+++ b/app/pages/ranking.vue
@@ -47,6 +47,7 @@ definePageMeta({
 
 // Auth state for conditional features
 const { isAuthenticated } = useAuth()
+const { goToSignup } = useAuthRedirect()
 
 // Tutorial for first-time users
 const { autoStartTutorial } = useTutorial()
@@ -719,7 +720,7 @@ watch(
             :explorer-link="explorerLink()"
             data-tour="ranking-actions"
             @copy-link="copyRankingLink"
-            @save-chart="navigateTo('/signup')"
+            @save-chart="goToSignup"
             @export-c-s-v="exportCSV"
             @export-j-s-o-n="exportJSON"
           >
@@ -787,7 +788,7 @@ watch(
             :show-screenshot="false"
             :explorer-link="explorerLink()"
             @copy-link="copyRankingLink"
-            @save-chart="navigateTo('/signup')"
+            @save-chart="goToSignup"
             @export-c-s-v="exportCSV"
             @export-j-s-o-n="exportJSON"
           >

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,7 +55,7 @@ export default defineNuxtConfig({
 
   // Route-specific rendering rules
   routeRules: {
-    '/explorer': { ssr: false }, // Client-only (interactive)
+    '/explorer': { ssr: true }, // SSR enabled for OG meta tags
     // Disable all prerendering to avoid build hangs from database connections
     '/': { ssr: true, prerender: false }, // Server-rendered (fetches dynamic featured charts)
     '/about': { ssr: true, prerender: false },

--- a/server/utils/chartPngHelpers.ts
+++ b/server/utils/chartPngHelpers.ts
@@ -312,7 +312,7 @@ export function generateChartConfig(
       state.showLogo,
       isDark,
       state.decimals,
-      undefined, // userTier
+      0, // userTier: PUBLIC tier - always show logo/QR for SSR (unauthenticated context)
       state.showCaption,
       state.showTitle,
       true // isSSR
@@ -338,7 +338,7 @@ export function generateChartConfig(
       state.showLogo,
       state.decimals,
       isDark,
-      undefined, // userTier
+      0, // userTier: PUBLIC tier - always show logo/QR for SSR (unauthenticated context)
       state.showCaption,
       state.showTitle,
       true, // isSSR

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -118,8 +118,8 @@ test.describe('Authentication Flow', () => {
       await page.getByRole('textbox', { name: 'Password*' }).fill('WrongPassword1!')
       await page.getByRole('button', { name: 'Continue' }).click()
 
-      // Should show error alert (401 Server Error)
-      await expect(page.getByText(/401 Server Error|Invalid email or password/i)).toBeVisible()
+      // Should show user-friendly error message
+      await expect(page.getByText('Invalid email or password')).toBeVisible()
 
       // Should stay on login page
       await expect(page).toHaveURL('/login')


### PR DESCRIPTION
## Summary

- **OG Image Fixes**: Enable SSR for explorer, fix meta tag rendering, include defaults in URLs
- **Tier Enforcement**: Logo/QR always shown for lower-tier users viewing premium charts
- **Error Messages**: Clean user-facing messages instead of ugly FetchError format
- **Auth Redirects**: Preserve current URL when redirecting to login/signup

## Changes

### OG Images
- Enable SSR for `/explorer` so meta tags render server-side for social media crawlers
- Fix `/charts/[slug].vue` to use functions for `ogImage`/`twitterImage` meta tags
- Add `includeDefaults` parameter to `chartStateToQueryString` so OG URLs include all state params

### Tier Enforcement for Logo/QR
- Pass user's tier to `MortalityChart.vue` for client-side enforcement
- Pass tier 0 (PUBLIC) in SSR to always show logo/QR on server-rendered images
- Fixes: lower-tier users viewing charts with `showLogo=false` now see the logo

### Error Message Display
- Reorder `ErrorHandler.extractErrorMessage` to check `error.data.message` first
- Skip FetchError's formatted messages like `[POST] /api/auth/signin: 401 Server Error`
- Users now see clean messages like "Invalid email or password"

### Auth Redirects
- New `useAuthRedirect` composable with `loginUrl`/`signupUrl` computed URLs
- Sign In/Sign Up buttons preserve current URL for redirect after auth
- Applied to: AppHeader, signup, check-email, explorer, ranking, ChartActions, UpgradeCard

## Test plan
- [ ] Visit `/explorer` and check page source for `og:image` meta tag with params
- [ ] Share an explorer URL on social media preview tool (e.g., Twitter card validator)
- [ ] As public user, view a saved chart with hidden logo - verify logo still shows
- [ ] Try invalid login - verify error message is clean, not `[POST]...401`
- [ ] Click Sign In from explorer - verify redirect back after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)