### PR TITLE
fix: default precision to 0 for deaths and population types

### DIFF
--- a/app/lib/chart/chartConfig.ts
+++ b/app/lib/chart/chartConfig.ts
@@ -182,7 +182,8 @@ export const makeBarLineChartConfig = (
     showQrCode = true
   }
 
-  const showDecimals = !isDeathsType && !isPopulationType
+  const isCountType = isDeathsType || isPopulationType
+  const showDecimals = !isCountType
 
   // Logo and QR code plugins overlay the chart, so no padding needed for them
   // They draw at absolute positions in corners without affecting chart layout
@@ -219,7 +220,8 @@ export const makeBarLineChartConfig = (
         data.ytitle.includes('Z-Score') ? 'zscore' : 'mortality', // Detect view from ytitle
         isDark,
         isSSR,
-        chartStyle
+        chartStyle,
+        isCountType
       ),
       scales: createScalesConfig(
         data,
@@ -228,7 +230,8 @@ export const makeBarLineChartConfig = (
         showDecimals,
         decimals,
         isDark,
-        isSSR
+        isSSR,
+        isCountType
       )
     },
     data: {

--- a/app/lib/chart/config/chartLabels.ts
+++ b/app/lib/chart/config/chartLabels.ts
@@ -62,13 +62,17 @@ export function computeChartPrecision(allValues: number[]): number {
  * Compute resolved decimals from chart data when in auto mode.
  * For percentages, values are stored as decimals (0.20 = 20%) so we
  * multiply by 100 to get the displayed magnitude.
+ * For count types (deaths/population), always use 0 decimals.
  */
 export function resolveDecimals(
   data: MortalityChartData,
   decimals: string,
-  isPercentage: boolean = false
+  isPercentage: boolean = false,
+  isCountType: boolean = false
 ): string | number {
   if (decimals !== 'auto') return decimals
+  // Count types (deaths/population) should always use 0 decimals
+  if (isCountType) return 0
   const values = extractYValues(data)
   // For percentages, compute precision based on displayed values (after *100)
   const displayedValues = isPercentage ? values.map(v => v * 100) : values

--- a/app/lib/chart/config/chartPlugins.ts
+++ b/app/lib/chart/config/chartPlugins.ts
@@ -81,6 +81,7 @@ export function createOnResizeHandler() {
  * @param isDark - Dark mode flag
  * @param isSSR - Server-side rendering flag (applies font metric adjustments)
  * @param chartStyle - Chart style for positioning adjustments
+ * @param isCountType - Whether the data is a count type (deaths/population) that should use 0 decimals
  */
 export function createDatalabelsConfig(
   data: MortalityChartData,
@@ -91,10 +92,11 @@ export function createDatalabelsConfig(
   decimals: string,
   isDark?: boolean,
   isSSR?: boolean,
-  chartStyle?: 'bar' | 'line' | 'matrix'
+  chartStyle?: 'bar' | 'line' | 'matrix',
+  isCountType: boolean = false
 ): CustomDatalabelsConfig {
   // Compute chart-wide precision for consistent label display
-  const resolvedDecimals = resolveDecimals(data, decimals, showPercentage)
+  const resolvedDecimals = resolveDecimals(data, decimals, showPercentage, isCountType)
 
   return {
     anchor: 'end' as const,
@@ -228,6 +230,7 @@ export function createAnnotationsFromReferenceLines(
  * @param isDark - Dark mode flag
  * @param isSSR - Server-side rendering flag (applies font metric adjustments)
  * @param chartStyle - Chart style for label positioning
+ * @param isCountType - Whether the data is a count type (deaths/population) that should use 0 decimals
  */
 export function createPluginsConfig(
   data: MortalityChartData,
@@ -243,7 +246,8 @@ export function createPluginsConfig(
   view: string = 'mortality',
   isDark?: boolean,
   isSSR?: boolean,
-  chartStyle?: 'bar' | 'line' | 'matrix'
+  chartStyle?: 'bar' | 'line' | 'matrix',
+  isCountType: boolean = false
 ) {
   const basePlugins = {
     title: {
@@ -284,7 +288,8 @@ export function createPluginsConfig(
       decimals,
       isDark,
       isSSR,
-      chartStyle
+      chartStyle,
+      isCountType
     ),
     ...(showQrCode && data.url ? { qrCodeUrl: data.url } : {}),
     showLogo,

--- a/app/lib/chart/config/chartScales.ts
+++ b/app/lib/chart/config/chartScales.ts
@@ -20,8 +20,12 @@ import { extractYValues, getLabelText } from './chartLabels'
 /**
  * Compute axis tick precision based on data range.
  * Uses 0 decimals for large values, more for small ranges.
+ * For count types (deaths/population), always use 0 decimals.
  */
-function computeAxisPrecision(data: MortalityChartData, isPercentage: boolean): number {
+function computeAxisPrecision(data: MortalityChartData, isPercentage: boolean, isCountType: boolean = false): number {
+  // Count types (deaths/population) should always use 0 decimals
+  if (isCountType) return 0
+
   const values = extractYValues(data)
   if (values.length === 0) return 0
 
@@ -46,6 +50,7 @@ function computeAxisPrecision(data: MortalityChartData, isPercentage: boolean): 
  * @param decimals - Decimal precision ('auto' or number string)
  * @param isDark - Dark mode flag
  * @param isSSR - Server-side rendering flag (applies font metric adjustments)
+ * @param isCountType - Whether the data is a count type (deaths/population) that should use 0 decimals
  */
 export function createScalesConfig(
   data: MortalityChartData,
@@ -54,11 +59,12 @@ export function createScalesConfig(
   showDecimals: boolean,
   decimals: string,
   isDark?: boolean,
-  isSSR?: boolean
+  isSSR?: boolean,
+  isCountType: boolean = false
 ) {
   // Compute axis-specific precision (less than data labels)
   const axisPrecision = decimals === 'auto'
-    ? computeAxisPrecision(data, showPercentage)
+    ? computeAxisPrecision(data, showPercentage, isCountType)
     : parseInt(decimals)
 
   // SSR font adjustments: node-canvas has slightly different text metrics


### PR DESCRIPTION
## Summary
- When using 'auto' decimals, deaths and population metrics now default to 0 decimal places instead of computing precision from data magnitude
- This provides cleaner display for count-based metrics (whole numbers like 1,234 instead of 1,234.5)

## Changes
- Add `isCountType` parameter to `resolveDecimals()` in chartLabels.ts
- Add `isCountType` parameter to `computeAxisPrecision()` in chartScales.ts
- Pass `isCountType` through `createPluginsConfig`/`createScalesConfig`
- Update `makeBarLineChartConfig` to compute and pass `isCountType`

## Test plan
- [x] TypeScript type checking passes
- [x] Unit tests pass (59 chart config tests)
- [x] Manually verify deaths/population charts show 0 decimal places

🤖 Generated with [Claude Code](https://claude.com/claude-code)