### PR TITLE
fix: add npm scripts for admin user management

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,12 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx scripts/seed-admin.ts",
     "db:reset": "sh scripts/reset-db.sh",
+    "admin:list-users": "npx tsx scripts/list-users.ts",
+    "admin:promote": "npx tsx scripts/promote-admin.ts",
+    "admin:demote": "npx tsx scripts/demote-admin.ts",
+    "admin:grant-pro": "npx tsx scripts/grant-pro.ts",
+    "admin:revoke-pro": "npx tsx scripts/revoke-pro.ts",
+    "admin:delete-user": "npx tsx scripts/delete-user.ts",
     "prepare": "node -e \"try{require('husky')}catch{}\""
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add missing npm scripts for admin CLI tools added in #344
- Uses `npx tsx` for compatibility with environments where tsx is not globally installed

## Scripts Added
| Script | Description |
|--------|-------------|
| `npm run admin:list-users` | List all users in database |
| `npm run admin:promote -- email` | Promote user to admin |
| `npm run admin:demote -- email` | Demote admin to user |
| `npm run admin:grant-pro -- email` | Grant Pro access |
| `npm run admin:revoke-pro -- email` | Revoke Pro access |
| `npm run admin:delete-user -- email --force` | Delete user |

## Test plan
- [x] Verify scripts are accessible via `npm run`
- [ ] Test each script works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)