### PR TITLE
fix: standardize brand name to 'Mortality Watch'

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -10,7 +10,7 @@ const { tier } = useAuth()
   <UFooter :ui="{ top: 'border-b border-default', left: 'lg:flex-initial', right: 'lg:flex-initial' }">
     <template #left>
       <p class="text-muted text-sm">
-        © {{ new Date().getFullYear() }} MortalityWatch. Open data for public health.
+        © {{ new Date().getFullYear() }} Mortality Watch. Open data for public health.
         <span class="mx-1 hidden lg:inline">·</span>
         <ULink
           to="/about"

--- a/app/composables/useChartOgImage.ts
+++ b/app/composables/useChartOgImage.ts
@@ -58,7 +58,7 @@ export function useChartOgImage(state: MaybeRef<Partial<ChartState>>) {
     const excess = isExcess ? 'Excess' : ''
     const type = currentState.type || 'mortality'
 
-    return `${excess} ${type} data for ${countryNames}. Interactive charts and analysis from MortalityWatch.`
+    return `${excess} ${type} data for ${countryNames}. Interactive charts and analysis from Mortality Watch.`
   })
 
   return {

--- a/app/pages/contact.vue
+++ b/app/pages/contact.vue
@@ -254,9 +254,9 @@ definePageMeta({
 // SEO metadata
 useSeoMeta({
   title: 'Contact Us',
-  description: 'Get in touch with the MortalityWatch team. We\'re here to help with questions, suggestions, and bug reports.',
-  ogTitle: 'Contact MortalityWatch',
-  ogDescription: 'Get in touch with the MortalityWatch team for support and inquiries.',
+  description: 'Get in touch with the Mortality Watch team. We\'re here to help with questions, suggestions, and bug reports.',
+  ogTitle: 'Contact Mortality Watch',
+  ogDescription: 'Get in touch with the Mortality Watch team for support and inquiries.',
   ogImage: '/og-image.png'
 })
 </script>

--- a/app/pages/donate.vue
+++ b/app/pages/donate.vue
@@ -2,8 +2,8 @@
   <div class="container mx-auto px-4 py-8">
     <div class="max-w-3xl mx-auto">
       <PageHeader
-        title="Support MortalityWatch"
-        description="MortalityWatch is sustained by Pro subscriptions. If you'd like to support our work beyond upgrading to Pro, we gratefully accept donations."
+        title="Support Mortality Watch"
+        description="Mortality Watch is sustained by Pro subscriptions. If you'd like to support our work beyond upgrading to Pro, we gratefully accept donations."
         max-width="md"
       />
 
@@ -158,9 +158,9 @@ definePageMeta({
 
 // SEO metadata
 useSeoMeta({
-  title: 'Support MortalityWatch',
-  description: 'MortalityWatch is sustained by Pro subscriptions. Support our work with a one-time donation or upgrade to Pro for advanced features.',
-  ogTitle: 'Support MortalityWatch',
+  title: 'Support Mortality Watch',
+  description: 'Mortality Watch is sustained by Pro subscriptions. Support our work with a one-time donation or upgrade to Pro for advanced features.',
+  ogTitle: 'Support Mortality Watch',
   ogDescription: 'Support mortality data infrastructure and feature development.',
   ogImage: '/og-image.png'
 })

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -165,7 +165,7 @@
       <UCard class="max-w-5xl mx-auto">
         <template #header>
           <h2 class="text-2xl font-bold text-center">
-            Why Choose MortalityWatch?
+            Why Choose Mortality Watch?
           </h2>
         </template>
         <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
@@ -317,12 +317,12 @@ definePageMeta({
 
 // SEO metadata
 useSeoMeta({
-  title: 'MortalityWatch - Track Global Mortality, Life Expectancy & Excess Deaths',
+  title: 'Mortality Watch - Track Global Mortality, Life Expectancy & Excess Deaths',
   description: 'The world\'s most comprehensive open mortality database with daily updates from 300+ countries and regions. Explore excess deaths, life expectancy trends, compare regions, and analyze with multiple baseline methods.',
-  ogTitle: 'MortalityWatch - Track Global Mortality & Life Expectancy',
+  ogTitle: 'Mortality Watch - Track Global Mortality & Life Expectancy',
   ogDescription: 'Free, open-source platform with 300+ regions, life expectancy tracking, multiple baseline methods, and daily updates from official sources.',
   ogImage: '/og-image.png',
-  twitterTitle: 'MortalityWatch - Global Mortality & Life Expectancy Database',
+  twitterTitle: 'Mortality Watch - Global Mortality & Life Expectancy Database',
   twitterDescription: 'Track mortality trends, life expectancy, and excess deaths across 300+ countries and regions with advanced statistical analysis.',
   twitterImage: '/og-image.png',
   twitterCard: 'summary_large_image'


### PR DESCRIPTION
## Summary
- Standardize brand name to "Mortality Watch" (with space) across all user-facing text
- Keep "@MortalityWatch" for social media handles only

## Files Changed
- `AppFooter.vue` - Copyright text
- `index.vue` - Heading and SEO meta tags
- `contact.vue` - SEO meta tags
- `donate.vue` - Page title and SEO meta tags
- `useChartOgImage.ts` - OG image description

## Rationale
"Mortality Watch" (with space) is more readable and professional for a data/research site. Similar to "Human Rights Watch", "Cancer Research UK" - feels more authoritative.

## Test plan
- [x] Visual review of changed text
- [ ] Verify footer, homepage, contact, and donate pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)