### PR TITLE
fix: make profile fields optional and add missing page titles

### DIFF
--- a/app/pages/charts/index.vue
+++ b/app/pages/charts/index.vue
@@ -120,6 +120,14 @@ definePageMeta({
   description: 'Explore published mortality visualizations from our community'
 })
 
+useSeoMeta({
+  title: 'Chart Gallery - Mortality Watch',
+  description: 'Explore published mortality visualizations from our community. Browse charts by type, popularity, or featured selections.',
+  ogTitle: 'Chart Gallery - Mortality Watch',
+  ogDescription: 'Explore published mortality visualizations from our community.',
+  ogImage: '/og-image.png'
+})
+
 // Use shared filter composable
 const {
   sortBy,

--- a/app/pages/logout.vue
+++ b/app/pages/logout.vue
@@ -56,4 +56,9 @@ onMounted(async () => {
 definePageMeta({
   title: 'Sign Out'
 })
+
+useSeoMeta({
+  title: 'Sign Out - Mortality Watch',
+  robots: 'noindex, nofollow'
+})
 </script>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 definePageMeta({
-  middleware: 'auth'
+  middleware: 'auth',
+  title: 'Profile'
+})
+
+useSeoMeta({
+  title: 'Profile - Mortality Watch',
+  description: 'Manage your Mortality Watch account settings, personal information, and subscription.',
+  ogTitle: 'Profile - Mortality Watch',
+  robots: 'noindex, nofollow'
 })
 
 const { user, updateProfile, refreshSession } = useAuth()

--- a/app/pages/verify-email/[token].vue
+++ b/app/pages/verify-email/[token].vue
@@ -2,7 +2,13 @@
 import { handleError } from '@/lib/errors/errorHandler'
 
 definePageMeta({
-  layout: 'auth'
+  layout: 'auth',
+  title: 'Verify Email'
+})
+
+useSeoMeta({
+  title: 'Verify Email - Mortality Watch',
+  robots: 'noindex, nofollow'
 })
 
 const route = useRoute()

--- a/server/api/user/profile.patch.ts
+++ b/server/api/user/profile.patch.ts
@@ -5,8 +5,8 @@ import { requireAuth, hashPassword } from '../../utils/auth'
 import { ProfileUpdateResponseSchema } from '../../schemas'
 
 const updateProfileSchema = z.object({
-  firstName: z.string().min(1, 'First name is required').max(50, 'First name is too long').optional(),
-  lastName: z.string().min(1, 'Last name is required').max(50, 'Last name is too long').optional(),
+  firstName: z.string().max(50, 'First name is too long').optional(),
+  lastName: z.string().max(50, 'Last name is too long').optional(),
   displayName: z.string().max(50, 'Display name is too long').optional(),
   currentPassword: z.string().optional(),
   newPassword: z


### PR DESCRIPTION
## Summary
Two fixes in one PR:

### 1. Profile API validation fix
- Remove `min(1)` validation from firstName/lastName fields
- All profile fields are now truly optional (can be empty strings or omitted)
- Fixes "First name is required" error when updating profile

### 2. Missing page titles (SEO)
Added `useSeoMeta` to pages that were missing it:

| Page | Title |
|------|-------|
| `profile.vue` | Profile - Mortality Watch |
| `charts/index.vue` | Chart Gallery - Mortality Watch |
| `verify-email/[token].vue` | Verify Email - Mortality Watch |
| `logout.vue` | Sign Out - Mortality Watch |

Auth-related pages use `robots: 'noindex, nofollow'` to prevent search indexing.

## Test plan
- [ ] Update profile with empty first/last name fields
- [ ] Verify page titles appear correctly in browser tabs
- [ ] Check meta tags in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)