### PR TITLE
feat: add subscription debugging scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "admin:grant-pro": "npx tsx scripts/grant-pro.ts",
     "admin:revoke-pro": "npx tsx scripts/revoke-pro.ts",
     "admin:delete-user": "npx tsx scripts/delete-user.ts",
+    "admin:check-subscription": "npx tsx scripts/check-subscription.ts",
+    "admin:link-subscription": "npx tsx scripts/link-subscription.ts",
     "prepare": "node -e \"try{require('husky')}catch{}\""
   },
   "dependencies": {

--- a/scripts/check-subscription.ts
+++ b/scripts/check-subscription.ts
@@ -1,0 +1,72 @@
+import { db, users, subscriptions, webhookEvents } from '../db'
+import { eq, desc } from 'drizzle-orm'
+
+/**
+ * Check subscription status for a user
+ * Usage: npx tsx scripts/check-subscription.ts user@example.com
+ */
+
+const email = process.argv[2]
+
+if (!email) {
+  console.error('Usage: npx tsx scripts/check-subscription.ts user@example.com')
+  process.exit(1)
+}
+
+// Find user
+const user = await db
+  .select()
+  .from(users)
+  .where(eq(users.email, email))
+  .get()
+
+if (!user) {
+  console.error(`❌ User not found: ${email}`)
+  process.exit(1)
+}
+
+console.log('\n=== User Info ===')
+console.log(`ID: ${user.id}`)
+console.log(`Email: ${user.email}`)
+console.log(`Tier: ${user.tier}`)
+console.log(`Role: ${user.role}`)
+
+// Check subscription
+const subscription = await db
+  .select()
+  .from(subscriptions)
+  .where(eq(subscriptions.userId, user.id))
+  .get()
+
+console.log('\n=== Subscription ===')
+if (subscription) {
+  console.log(`Status: ${subscription.status}`)
+  console.log(`Plan: ${subscription.plan}`)
+  console.log(`Stripe Customer ID: ${subscription.stripeCustomerId}`)
+  console.log(`Stripe Subscription ID: ${subscription.stripeSubscriptionId}`)
+  console.log(`Current Period End: ${subscription.currentPeriodEnd}`)
+  console.log(`Cancel At Period End: ${subscription.cancelAtPeriodEnd}`)
+} else {
+  console.log('❌ No subscription found for this user')
+}
+
+// Check recent webhook events
+console.log('\n=== Recent Webhook Events (last 10) ===')
+const events = await db
+  .select()
+  .from(webhookEvents)
+  .orderBy(desc(webhookEvents.createdAt))
+  .limit(10)
+  .all()
+
+if (events.length === 0) {
+  console.log('❌ No webhook events found')
+} else {
+  for (const event of events) {
+    const status = event.processed ? '✅' : event.processingError ? '❌' : '⏳'
+    console.log(`${status} ${event.eventType} - ${event.stripeEventId} (${event.createdAt})`)
+    if (event.processingError) {
+      console.log(`   Error: ${event.processingError}`)
+    }
+  }
+}

--- a/scripts/link-subscription.ts
+++ b/scripts/link-subscription.ts
@@ -1,0 +1,127 @@
+import Stripe from 'stripe'
+import { db, users, subscriptions } from '../db'
+import { eq } from 'drizzle-orm'
+
+/**
+ * Link a Stripe subscription to a user (for when webhook fails)
+ * Usage: npx tsx scripts/link-subscription.ts user@example.com sub_xxxxx
+ */
+
+const email = process.argv[2]
+const stripeSubscriptionId = process.argv[3]
+
+if (!email || !stripeSubscriptionId) {
+  console.error('Usage: npx tsx scripts/link-subscription.ts user@example.com sub_xxxxx')
+  process.exit(1)
+}
+
+if (!stripeSubscriptionId.startsWith('sub_')) {
+  console.error('❌ Invalid subscription ID. Must start with "sub_"')
+  process.exit(1)
+}
+
+// Check Stripe API key
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY
+if (!stripeSecretKey) {
+  console.error('❌ STRIPE_SECRET_KEY environment variable not set')
+  process.exit(1)
+}
+
+// Find user
+const user = await db
+  .select()
+  .from(users)
+  .where(eq(users.email, email))
+  .get()
+
+if (!user) {
+  console.error(`❌ User not found: ${email}`)
+  process.exit(1)
+}
+
+console.log(`\nUser: ${user.email} (ID: ${user.id})`)
+
+// Fetch subscription from Stripe
+const stripe = new Stripe(stripeSecretKey)
+let stripeSubscription: Stripe.Subscription
+
+try {
+  stripeSubscription = await stripe.subscriptions.retrieve(stripeSubscriptionId)
+} catch (error) {
+  console.error(`❌ Failed to fetch subscription from Stripe: ${error}`)
+  process.exit(1)
+}
+
+console.log(`\nStripe Subscription:`)
+console.log(`  ID: ${stripeSubscription.id}`)
+console.log(`  Status: ${stripeSubscription.status}`)
+console.log(`  Customer: ${stripeSubscription.customer}`)
+
+// Get customer ID
+const customerId = typeof stripeSubscription.customer === 'string'
+  ? stripeSubscription.customer
+  : stripeSubscription.customer.id
+
+// Access with snake_case
+const sub = stripeSubscription as unknown as {
+  current_period_start: number
+  current_period_end: number
+  cancel_at_period_end: boolean
+  canceled_at: number | null
+  trial_end: number | null
+}
+
+// Determine plan
+const priceId = stripeSubscription.items.data[0]?.price.id
+let plan: 'monthly' | 'yearly' | null = null
+if (priceId === process.env.STRIPE_PRICE_MONTHLY) {
+  plan = 'monthly'
+} else if (priceId === process.env.STRIPE_PRICE_YEARLY) {
+  plan = 'yearly'
+} else {
+  // Try to infer from interval
+  const interval = stripeSubscription.items.data[0]?.price.recurring?.interval
+  plan = interval === 'year' ? 'yearly' : 'monthly'
+}
+
+console.log(`  Plan: ${plan}`)
+
+// Check for existing subscription
+const existingSubscription = await db
+  .select()
+  .from(subscriptions)
+  .where(eq(subscriptions.userId, user.id))
+  .get()
+
+const subscriptionData = {
+  userId: user.id,
+  stripeCustomerId: customerId,
+  stripeSubscriptionId: stripeSubscription.id,
+  status: stripeSubscription.status as 'active' | 'canceled' | 'past_due' | 'unpaid' | 'incomplete' | 'trialing' | 'inactive',
+  plan,
+  planPriceId: priceId || null,
+  currentPeriodStart: new Date(sub.current_period_start * 1000),
+  currentPeriodEnd: new Date(sub.current_period_end * 1000),
+  cancelAtPeriodEnd: sub.cancel_at_period_end || false,
+  canceledAt: sub.canceled_at ? new Date(sub.canceled_at * 1000) : null,
+  trialEnd: sub.trial_end ? new Date(sub.trial_end * 1000) : null,
+  updatedAt: new Date()
+}
+
+if (existingSubscription) {
+  console.log(`\nUpdating existing subscription...`)
+  await db
+    .update(subscriptions)
+    .set(subscriptionData)
+    .where(eq(subscriptions.userId, user.id))
+} else {
+  console.log(`\nCreating new subscription...`)
+  await db.insert(subscriptions).values(subscriptionData)
+}
+
+// Update user tier
+const tier = stripeSubscription.status === 'active' || stripeSubscription.status === 'trialing' ? 2 : 1
+await db.update(users).set({ tier }).where(eq(users.id, user.id))
+
+console.log(`\n✅ Subscription linked successfully!`)
+console.log(`   User tier updated to: ${tier}`)


### PR DESCRIPTION
## Summary
Add admin scripts to debug and fix Stripe subscription issues when webhooks fail to reach the server (e.g., staging environments).

### New Scripts

**`npm run admin:check-subscription -- user@example.com`**
- Shows user info (ID, email, tier)
- Shows subscription details (status, plan, Stripe IDs)
- Lists recent webhook events (last 10)

**`npm run admin:link-subscription -- user@example.com sub_xxxxx`**
- Manually links a Stripe subscription to a user
- Fetches subscription details directly from Stripe API
- Creates/updates local subscription record
- Updates user tier

## Use Case
When a user completes payment but the webhook doesn't reach the server:
1. Run `check-subscription` to diagnose
2. Run `link-subscription` with the Stripe subscription ID to fix

## Test plan
- [ ] Run check-subscription for a test user
- [ ] Run link-subscription with a valid Stripe subscription ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)