### PR TITLE
fix: subscription UX issues after Stripe redirect

### DIFF
--- a/app/components/SubscriptionCard.vue
+++ b/app/components/SubscriptionCard.vue
@@ -109,8 +109,11 @@ onMounted(() => {
   loadSubscriptionStatus()
 })
 
-// Reload subscription when returning from Stripe portal
+// Reload subscription and reset states when returning from Stripe portal
 onActivated(() => {
+  // Reset loading states in case user navigated back with browser button
+  subscribing.value = false
+  managingSubscription.value = false
   loadSubscriptionStatus()
 })
 </script>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -31,18 +31,16 @@ onMounted(async () => {
       description: 'Your payment was successful. Welcome to Pro! 🎉',
       color: 'success'
     })
-    // Clean up the URL
-    const router = useRouter()
-    router.replace({ query: {} })
+    // Clean up the URL without triggering Vue Router navigation/middleware
+    window.history.replaceState({}, '', '/profile')
   } else if (route.query.canceled === 'true') {
     toast.add({
       title: 'Checkout canceled',
       description: 'You can subscribe anytime from your profile.',
       color: 'info'
     })
-    // Clean up the URL
-    const router = useRouter()
-    router.replace({ query: {} })
+    // Clean up the URL without triggering Vue Router navigation/middleware
+    window.history.replaceState({}, '', '/profile')
   }
 })
 


### PR DESCRIPTION
## Summary
Fix two UX issues with the Stripe subscription flow:

### 1. Logout after successful subscription
**Problem:** After completing Stripe checkout, user briefly sees "Subscription activated!" toast, then gets logged out.

**Cause:** `router.replace({ query: {} })` triggered Vue Router navigation which re-ran the auth middleware.

**Fix:** Use `window.history.replaceState` instead, which updates the URL without triggering Vue Router middleware.

### 2. Stuck loading state on buttons
**Problem:** After clicking "Manage Subscription" and using browser back button, the loading spinner remained on the button.

**Cause:** `managingSubscription.value = true` was set before redirect, but never reset when returning.

**Fix:** Reset `subscribing` and `managingSubscription` states in `onActivated` hook.

## Test plan
- [ ] Subscribe via Stripe, verify no logout after returning
- [ ] Click "Manage Subscription", press browser back, verify button is not stuck loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)