### PR TITLE
fix: auth session persistence and UI component updates

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -207,19 +207,18 @@ const userMenuItems = computed<MenuItem[]>(() => {
       />
 
       <!-- Authentication buttons -->
-      <template v-if="isAuthenticated">
-        <UDropdownMenu
-          :items="[userMenuItems]"
-          :popper="{ placement: 'bottom-end' }"
-        >
-          <UButton
-            variant="ghost"
-            icon="i-lucide-user"
-            :label="user?.displayName || user?.firstName || 'Account'"
-            trailing-icon="i-lucide-chevron-down"
-          />
-        </UDropdownMenu>
-      </template>
+      <UDropdownMenu
+        v-if="isAuthenticated"
+        :items="[userMenuItems]"
+        :content="{ align: 'end' }"
+      >
+        <UButton
+          variant="ghost"
+          icon="i-lucide-user"
+          :label="user?.displayName || user?.firstName || 'Account'"
+          trailing-icon="i-lucide-chevron-down"
+        />
+      </UDropdownMenu>
       <template v-else>
         <UButton
           :to="loginUrl"

--- a/app/components/DeleteAccountModal.vue
+++ b/app/components/DeleteAccountModal.vue
@@ -90,30 +90,12 @@ function handleClose(): void {
 
 <template>
   <UModal
-    :model-value="open"
-    :prevent-close="deleting"
-    @update:model-value="handleClose"
+    :open="open"
+    :title="`Delete Account - Step ${step} of 2`"
+    :close="{ color: 'neutral', variant: 'ghost' }"
+    @update:open="handleClose"
   >
-    <UCard>
-      <template #header>
-        <div class="flex items-center gap-3">
-          <div class="shrink-0 w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center">
-            <UIcon
-              name="i-lucide-alert-triangle"
-              class="w-5 h-5 text-red-600 dark:text-red-400"
-            />
-          </div>
-          <div>
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-              Delete Account
-            </h3>
-            <p class="text-sm text-gray-500 dark:text-gray-400">
-              Step {{ step }} of 2
-            </p>
-          </div>
-        </div>
-      </template>
-
+    <template #body>
       <!-- Step 1: Confirmation -->
       <div
         v-if="step === 1"
@@ -189,51 +171,51 @@ function handleClose(): void {
           </p>
         </div>
       </div>
+    </template>
 
-      <template #footer>
-        <div class="flex items-center justify-between gap-3">
+    <template #footer>
+      <div class="flex items-center justify-between gap-3 w-full">
+        <UButton
+          v-if="step === 2"
+          color="neutral"
+          variant="ghost"
+          :disabled="deleting"
+          @click="previousStep"
+        >
+          Back
+        </UButton>
+        <div
+          v-else
+          class="flex-1"
+        />
+        <div class="flex items-center gap-3">
           <UButton
-            v-if="step === 2"
             color="neutral"
-            variant="ghost"
+            variant="soft"
             :disabled="deleting"
-            @click="previousStep"
+            @click="handleClose"
           >
-            Back
+            Cancel
           </UButton>
-          <div
+          <UButton
+            v-if="step === 1"
+            color="error"
+            :disabled="!isConfirmValid || deleting"
+            @click="nextStep"
+          >
+            Continue
+          </UButton>
+          <UButton
             v-else
-            class="flex-1"
-          />
-          <div class="flex items-center gap-3">
-            <UButton
-              color="neutral"
-              variant="soft"
-              :disabled="deleting"
-              @click="handleClose"
-            >
-              Cancel
-            </UButton>
-            <UButton
-              v-if="step === 1"
-              color="error"
-              :disabled="!isConfirmValid || deleting"
-              @click="nextStep"
-            >
-              Continue
-            </UButton>
-            <UButton
-              v-else
-              color="error"
-              :loading="deleting"
-              :disabled="!password || deleting"
-              @click="confirmDeletion"
-            >
-              Delete Account Permanently
-            </UButton>
-          </div>
+            color="error"
+            :loading="deleting"
+            :disabled="!password || deleting"
+            @click="confirmDeletion"
+          >
+            Delete Account Permanently
+          </UButton>
         </div>
-      </template>
-    </UCard>
+      </div>
+    </template>
   </UModal>
 </template>

--- a/app/lib/data/validation.test.ts
+++ b/app/lib/data/validation.test.ts
@@ -118,9 +118,9 @@ US,United States,2020-01-01,2023-12-31,3,0-100,cdc`
         expect(result.success).toBe(false)
       })
 
-      it('should reject invalid ISO3C code (too long, >6 chars)', async () => {
+      it('should reject invalid ISO3C code (too long, >7 chars)', async () => {
         const csv = `iso3c,jurisdiction,min_date,max_date,type,age_groups,source
-USA-FLA,United States,2020-01-01,2023-12-31,3,0-100,cdc`
+USA-FLAX,United States,2020-01-01,2023-12-31,3,0-100,cdc`
 
         const result = await validateMetadata(csv)
 
@@ -134,6 +134,21 @@ USA-FL,USA - Florida,2020-01-01,2023-12-31,3,0-100,cdc`
         const result = await validateMetadata(csv)
 
         expect(result.success).toBe(true)
+      })
+
+      it('should accept UK constituent country codes (7 chars)', async () => {
+        const csv = `iso3c,jurisdiction,min_date,max_date,type,age_groups,source
+GBRTENW,England & Wales,2020-01-01,2023-12-31,3,0-100,mortality_org
+GBR_SCO,Scotland,2020-01-01,2023-12-31,3,0-100,mortality_org
+GBR_NIR,Northern Ireland,2020-01-01,2023-12-31,3,0-100,mortality_org`
+
+        const result = await validateMetadata(csv)
+
+        expect(result.success).toBe(true)
+        expect(result.data).toHaveLength(3)
+        expect(result.data![0]!.iso3c).toBe('GBRTENW')
+        expect(result.data![1]!.iso3c).toBe('GBR_SCO')
+        expect(result.data![2]!.iso3c).toBe('GBR_NIR')
       })
 
       it('should reject empty jurisdiction', async () => {

--- a/app/lib/data/validation.ts
+++ b/app/lib/data/validation.ts
@@ -27,8 +27,9 @@ const log = logger.withPrefix('Validation')
  * @property {string} source - Data source identifier
  */
 const CountryRawSchema = z.object({
-  // Allow 3-letter codes (USA, DEU) or hyphenated sub-country codes (USA-FL, DEU-SN, CAN-ON)
-  iso3c: z.string().min(3).max(6),
+  // Allow 3-letter codes (USA, DEU), hyphenated sub-country codes (USA-FL, DEU-SN, CAN-ON),
+  // or special UK codes (GBRTENW, GBR_SCO, GBR_NIR)
+  iso3c: z.string().min(3).max(7),
   jurisdiction: z.string().min(1),
   min_date: z.string(),
   max_date: z.string(),
@@ -62,8 +63,9 @@ const CountryRawSchema = z.object({
  * @property {string} [asmr_country] - Age-standardized mortality rate (country-specific, optional)
  */
 const CountryDataRawSchema = z.object({
-  // Allow 3-letter codes (USA, DEU) or hyphenated sub-country codes (USA-FL, DEU-SN, CAN-ON)
-  iso3c: z.string().min(3).max(6),
+  // Allow 3-letter codes (USA, DEU), hyphenated sub-country codes (USA-FL, DEU-SN, CAN-ON),
+  // or special UK codes (GBRTENW, GBR_SCO, GBR_NIR)
+  iso3c: z.string().min(3).max(7),
   population: z.string(),
   date: z.string(),
   type: z.string(),


### PR DESCRIPTION
## Summary

- Fix session not persisting after Stripe redirect by using `useRequestFetch()` on server for SSR cookie forwarding
- Update DeleteAccountModal to Nuxt UI v4 pattern with `#body`/`#footer` slots
- Fix AppHeader dropdown using v4 API (`content` instead of `popper`)
- Allow UK constituent country codes (GBRTENW, GBR_SCO, GBR_NIR) in validation

## Test plan

- [ ] Sign in with "remember me", go through Stripe checkout, verify session persists after redirect
- [ ] Test delete account modal opens and displays correctly
- [ ] Test profile dropdown menu works when authenticated
- [ ] Verify UK country codes are accepted in data validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)