### PR TITLE
fix: admin Pro recognition and thumbnail logo/QR display

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -8,7 +8,8 @@ interface MenuItem {
 }
 
 const { isIncognito } = useIncognitoMode()
-const { isAuthenticated, user, tier } = useAuth()
+const { isAuthenticated, user } = useAuth()
+const { isPro } = useFeatureAccess()
 const { startTutorial } = useTutorial()
 const { loginUrl, signupUrl } = useAuthRedirect()
 const colorMode = useColorMode()
@@ -91,8 +92,8 @@ const items = computed(() => {
     to: '/charts'
   })
 
-  // Add "Features" for non-pro users (PUBLIC and REGISTERED, tier < 2)
-  if (tier.value < 2) {
+  // Add "Features" for non-pro users (PUBLIC and REGISTERED)
+  if (!isPro.value) {
     navItems.push({
       label: 'Features',
       icon: 'i-lucide-sparkles',
@@ -119,8 +120,8 @@ const secondaryItems = computed<MenuItem[]>(() => {
     to: '/methods'
   }]
 
-  // Add Features if tier 2
-  if (tier.value === 2) {
+  // Add Features for Pro users in secondary nav
+  if (isPro.value) {
     navItems.push({
       label: 'Features',
       icon: 'i-lucide-sparkles',

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "admin:delete-user": "npx tsx scripts/delete-user.ts",
     "admin:check-subscription": "npx tsx scripts/check-subscription.ts",
     "admin:link-subscription": "npx tsx scripts/link-subscription.ts",
+    "cache:clear": "rm -rf .data/cache/charts && echo 'Chart cache cleared'",
     "prepare": "node -e \"try{require('husky')}catch{}\""
   },
   "dependencies": {

--- a/server/utils/chartPngHelpers.ts
+++ b/server/utils/chartPngHelpers.ts
@@ -298,6 +298,12 @@ export function generateChartConfig(
   // This ensures bar/line charts also respect the auto-hide logic
   const dataWithEffectiveLabels = { ...data, showLabels: effectiveShowLabels }
 
+  // Determine userTier for feature gating:
+  // - If showLogo or showQrCode are explicitly false (e.g., for thumbnails), pass undefined
+  //   to bypass tier-based enforcement and respect the explicit values
+  // - Otherwise, pass 0 (PUBLIC tier) to enforce logo/QR for unauthenticated SSR
+  const userTier = (!state.showLogo || !state.showQrCode) ? undefined : 0
+
   if (state.chartStyle === 'matrix') {
     const config = makeMatrixChartConfig(
       dataWithEffectiveLabels,
@@ -312,7 +318,7 @@ export function generateChartConfig(
       state.showLogo,
       isDark,
       state.decimals,
-      0, // userTier: PUBLIC tier - always show logo/QR for SSR (unauthenticated context)
+      userTier,
       state.showCaption,
       state.showTitle,
       true // isSSR
@@ -338,7 +344,7 @@ export function generateChartConfig(
       state.showLogo,
       state.decimals,
       isDark,
-      0, // userTier: PUBLIC tier - always show logo/QR for SSR (unauthenticated context)
+      userTier,
       state.showCaption,
       state.showTitle,
       true, // isSSR


### PR DESCRIPTION
- SubscriptionCard: Recognize admin users and tier 2 users as having Pro access, showing "Pro (Admin)" or "Pro Access" badge instead of subscription options
- chartPngHelpers: Allow hiding logo/QR on thumbnails by bypassing tier-based enforcement when showLogo or showQrCode are explicitly false in URL params
- package.json: Add cache:clear script for clearing chart cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)