### PR TITLE
feat: add browse all charts page

### DIFF
--- a/app/pages/charts/browse.vue
+++ b/app/pages/charts/browse.vue
@@ -1,0 +1,272 @@
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <!-- Header -->
+    <div class="mb-8">
+      <h1 class="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+        Browse All Charts
+      </h1>
+      <p class="text-lg text-gray-600 dark:text-gray-400">
+        All charts ever created on the platform
+      </p>
+    </div>
+
+    <!-- Sort Controls -->
+    <div class="mb-6 flex items-center gap-4">
+      <span class="text-sm text-gray-600 dark:text-gray-400">Sort by:</span>
+      <div class="flex gap-2">
+        <UButton
+          :variant="sortBy === 'newest' ? 'solid' : 'outline'"
+          size="sm"
+          @click="sortBy = 'newest'"
+        >
+          Newest
+        </UButton>
+        <UButton
+          :variant="sortBy === 'popular' ? 'solid' : 'outline'"
+          size="sm"
+          @click="sortBy = 'popular'"
+        >
+          Most Viewed
+        </UButton>
+        <UButton
+          :variant="sortBy === 'recent' ? 'solid' : 'outline'"
+          size="sm"
+          @click="sortBy = 'recent'"
+        >
+          Recently Accessed
+        </UButton>
+      </div>
+    </div>
+
+    <!-- Loading State -->
+    <LoadingSpinner
+      v-if="pending"
+      text="Loading charts..."
+      size="lg"
+      height="h-64"
+    />
+
+    <!-- Error State -->
+    <UAlert
+      v-else-if="error"
+      color="error"
+      variant="subtle"
+      title="Error loading charts"
+      :description="error.message"
+    />
+
+    <!-- Charts Grid -->
+    <div
+      v-else-if="charts && charts.length > 0"
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+    >
+      <UCard
+        v-for="chart in charts"
+        :key="chart.id"
+        class="hover:shadow-lg transition-shadow"
+      >
+        <!-- Thumbnail -->
+        <NuxtLink
+          :to="getChartUrl(chart)"
+          class="block overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800 mb-3"
+          style="aspect-ratio: 16/9"
+        >
+          <img
+            :src="getThumbnailUrl(chart)"
+            :alt="`Chart ${chart.id}`"
+            class="w-full h-full object-cover object-top hover:scale-105 transition-transform"
+            loading="lazy"
+          >
+        </NuxtLink>
+
+        <!-- Meta info -->
+        <div class="space-y-2">
+          <!-- Stats row -->
+          <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+            <div class="flex items-center gap-3">
+              <UBadge
+                :color="chart.page === 'explorer' ? 'primary' : 'info'"
+                variant="subtle"
+                size="xs"
+              >
+                {{ chart.page }}
+              </UBadge>
+              <span>
+                <Icon
+                  name="i-lucide-eye"
+                  class="w-3 h-3 inline"
+                />
+                {{ chart.accessCount }}
+              </span>
+            </div>
+            <span>{{ formatDate(chart.createdAt) }}</span>
+          </div>
+
+          <!-- Admin: Saved By -->
+          <div
+            v-if="isAdmin && chart.savedBy"
+            class="text-xs text-gray-500 dark:text-gray-400"
+          >
+            <Icon
+              name="i-lucide-bookmark"
+              class="w-3 h-3 inline"
+            />
+            Saved by {{ chart.savedBy.name }}
+            <span v-if="chart.savedBy.count > 1">
+              (+{{ chart.savedBy.count - 1 }})
+            </span>
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <!-- Empty State -->
+    <UCard v-else-if="!pending">
+      <div class="text-center py-12">
+        <Icon
+          name="i-lucide-inbox"
+          class="w-16 h-16 mx-auto text-gray-400 mb-4"
+        />
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
+          No charts found
+        </h3>
+        <p class="text-gray-600 dark:text-gray-400">
+          No charts have been created yet
+        </p>
+      </div>
+    </UCard>
+
+    <!-- Pagination -->
+    <div
+      v-if="pagination && pagination.total > pagination.limit"
+      class="mt-8 flex justify-center items-center gap-4"
+    >
+      <span class="text-sm text-gray-600 dark:text-gray-400">
+        Showing {{ pagination.offset + 1 }}-{{ Math.min(pagination.offset + pagination.limit, pagination.total) }}
+        of {{ pagination.total.toLocaleString() }} charts
+      </span>
+      <UPagination
+        v-model="currentPage"
+        :total="pagination.total"
+        :page-count="pagination.limit"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Chart {
+  id: string
+  page: 'explorer' | 'ranking'
+  config: string
+  createCount: number
+  accessCount: number
+  createdAt: string
+  lastAccessedAt: string | null
+  savedBy?: { name: string, count: number } | null
+}
+
+const { user } = useAuth()
+const isAdmin = computed(() => user.value?.role === 'admin')
+const colorMode = useColorMode()
+
+interface Pagination {
+  total: number
+  limit: number
+  offset: number
+  hasMore: boolean
+}
+
+// Page meta
+definePageMeta({
+  title: 'Browse All Charts'
+})
+
+useSeoMeta({
+  title: 'Browse All Charts',
+  description: 'Browse all charts ever created on Mortality Watch',
+  ogTitle: 'Browse All Charts - Mortality Watch',
+  ogDescription: 'Browse all charts ever created on Mortality Watch'
+})
+
+// State
+const sortBy = ref<'newest' | 'popular' | 'recent'>('newest')
+const currentPage = ref(1)
+const limit = 24 // Better for grid layout (divisible by 2 and 3)
+
+// Computed query params
+const queryParams = computed(() => ({
+  sort: sortBy.value,
+  limit,
+  offset: (currentPage.value - 1) * limit
+}))
+
+// Reset to page 1 when sort changes
+watch(sortBy, () => {
+  currentPage.value = 1
+})
+
+// Fetch charts
+const { data, pending, error } = await useFetch<{
+  charts: Chart[]
+  pagination: Pagination
+}>('/api/charts/browse', {
+  query: queryParams,
+  watch: [queryParams]
+})
+
+const charts = computed(() => data.value?.charts || [])
+const pagination = computed(() => data.value?.pagination)
+
+// Format date (ISO string from API)
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '-'
+  const date = new Date(dateStr)
+  if (isNaN(date.getTime())) return '-'
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+}
+
+// Get direct URL to chart (strip display-only params)
+function getChartUrl(chart: Chart): string {
+  const base = `/${chart.page}`
+  if (!chart.config) return base
+
+  // Remove thumbnail/display-only params that shouldn't be in deep links
+  const params = new URLSearchParams(chart.config)
+  const displayParams = ['l', 'qr', 'cap', 'ti', 'dm', 'dp', 'z', 'width', 'height']
+  displayParams.forEach(p => params.delete(p))
+
+  const cleanConfig = params.toString()
+  return cleanConfig ? `${base}?${cleanConfig}` : base
+}
+
+// Generate thumbnail URL (same approach as ChartCard)
+function getThumbnailUrl(chart: Chart): string {
+  const endpoint = chart.page === 'ranking' ? '/ranking.png' : '/chart.png'
+  const params = new URLSearchParams(chart.config)
+
+  // First, remove any stored display params to reset to defaults
+  const displayParams = ['l', 'qr', 'cap', 'ti', 'dm', 'dp', 'z', 'width', 'height']
+  displayParams.forEach(p => params.delete(p))
+
+  // Add dark mode if active
+  if (colorMode.value === 'dark') {
+    params.set('dm', '1')
+  }
+
+  // Thumbnail-specific options (title stays visible by default)
+  params.set('qr', '0') // Hide QR code
+  params.set('l', '0') // Hide logo
+  params.set('cap', '0') // Hide caption
+  params.set('dp', '2') // 2x device pixel ratio
+  params.set('z', '1.5') // Zoom level
+  params.set('width', '352')
+  params.set('height', '198')
+
+  return `${endpoint}?${params.toString()}`
+}
+</script>

--- a/app/pages/charts/index.vue
+++ b/app/pages/charts/index.vue
@@ -2,9 +2,17 @@
   <div class="container mx-auto px-4 py-8">
     <!-- Header -->
     <div class="mb-8">
-      <h1 class="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-        Chart Gallery
-      </h1>
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-4xl font-bold text-gray-900 dark:text-gray-100">
+          Chart Gallery
+        </h1>
+        <UButton
+          to="/charts/browse"
+          variant="outline"
+          icon="i-lucide-list"
+          label="Browse All Charts"
+        />
+      </div>
       <p class="text-lg text-gray-600 dark:text-gray-400">
         Explore published mortality visualizations from our community
       </p>

--- a/server/api/charts/browse.get.ts
+++ b/server/api/charts/browse.get.ts
@@ -1,0 +1,135 @@
+import { db } from '../../utils/db'
+import { charts, savedCharts, users } from '../../../db/schema'
+import { desc, sql, eq } from 'drizzle-orm'
+
+/**
+ * GET /api/charts/browse
+ *
+ * Get all charts ever created (for browsing)
+ * Query params:
+ * - limit: number (default 50, max 100)
+ * - offset: number (default 0)
+ * - sort: 'newest' | 'popular' | 'recent' (default 'newest')
+ *
+ * Admin users see additional author info (who saved the chart, if anyone)
+ */
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const user = await getCurrentUser(event)
+  const isAdmin = user?.role === 'admin'
+
+  const limit = Math.min(parseInt(query.limit as string) || 50, 100)
+  const offset = parseInt(query.offset as string) || 0
+  const sort = (query.sort as string) || 'newest'
+
+  try {
+    // Determine sort order
+    let orderBy
+    switch (sort) {
+      case 'popular':
+        orderBy = [desc(charts.accessCount), desc(charts.createdAt)]
+        break
+      case 'recent':
+        // Most recently accessed
+        orderBy = [desc(charts.lastAccessedAt), desc(charts.createdAt)]
+        break
+      case 'newest':
+      default:
+        orderBy = [desc(charts.createdAt)]
+        break
+    }
+
+    // Query all charts
+    const results = await db
+      .select({
+        id: charts.id,
+        page: charts.page,
+        config: charts.config,
+        createCount: charts.createCount,
+        accessCount: charts.accessCount,
+        createdAt: charts.createdAt,
+        lastAccessedAt: charts.lastAccessedAt
+      })
+      .from(charts)
+      .orderBy(...orderBy)
+      .limit(limit)
+      .offset(offset)
+
+    // For admins, fetch saved chart info to show who saved each chart
+    let savedByMap: Map<string, { name: string, count: number }> = new Map()
+    if (isAdmin && results.length > 0) {
+      const chartIds = results.map(c => c.id)
+      const savedInfo = await db
+        .select({
+          chartId: savedCharts.chartId,
+          displayName: users.displayName,
+          firstName: users.firstName,
+          email: users.email
+        })
+        .from(savedCharts)
+        .leftJoin(users, eq(savedCharts.userId, users.id))
+        .where(sql`${savedCharts.chartId} IN (${sql.join(chartIds.map(id => sql`${id}`), sql`, `)})`)
+
+      // Group by chartId and get first saver + count
+      const chartSavers: Map<string, { names: string[], count: number }> = new Map()
+      for (const info of savedInfo) {
+        const existing = chartSavers.get(info.chartId) || { names: [], count: 0 }
+        const name = info.displayName || info.firstName || info.email || 'Unknown'
+        existing.names.push(name)
+        existing.count++
+        chartSavers.set(info.chartId, existing)
+      }
+
+      savedByMap = new Map(
+        Array.from(chartSavers.entries()).map(([chartId, data]) => [
+          chartId,
+          { name: data.names[0] || 'Unknown', count: data.count }
+        ])
+      )
+    }
+
+    // Get total count for pagination
+    const totalResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(charts)
+
+    const total = totalResult[0]?.count || 0
+
+    return {
+      charts: results.map(chart => ({
+        ...chart,
+        // Only include savedBy for admins
+        savedBy: isAdmin ? savedByMap.get(chart.id) || null : undefined
+      })),
+      pagination: {
+        total,
+        limit,
+        offset,
+        hasMore: offset + limit < total
+      }
+    }
+  } catch (err) {
+    logger.error('Error fetching charts for browse:', err instanceof Error ? err : new Error(String(err)))
+
+    // Handle missing table gracefully
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'SQLITE_ERROR') {
+      const message = 'message' in err ? String(err.message) : ''
+      if (message.includes('no such table')) {
+        return {
+          charts: [],
+          pagination: {
+            total: 0,
+            limit,
+            offset,
+            hasMore: false
+          }
+        }
+      }
+    }
+
+    throw createError({
+      statusCode: 500,
+      message: 'Failed to fetch charts'
+    })
+  }
+})

--- a/tests/e2e/browse-charts.spec.ts
+++ b/tests/e2e/browse-charts.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Browse All Charts Page', () => {
+  test('should load browse page successfully', async ({ page }) => {
+    await page.goto('/charts/browse')
+
+    // Verify page loaded
+    await expect(page).toHaveURL(/\/charts\/browse/)
+  })
+
+  test('should display page heading and description', async ({ page }) => {
+    await page.goto('/charts/browse')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Check heading
+    const heading = page.getByRole('heading', { name: 'Browse All Charts' })
+    await expect(heading).toBeVisible()
+
+    // Check description
+    const description = page.getByText('All charts ever created on the platform')
+    await expect(description).toBeVisible()
+  })
+
+  test('should display sort controls', async ({ page }) => {
+    await page.goto('/charts/browse')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Check sort buttons
+    await expect(page.getByRole('button', { name: 'Newest' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Most Viewed' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Recently Accessed' })).toBeVisible()
+  })
+
+  test('should have link from gallery page', async ({ page }) => {
+    await page.goto('/charts')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Check the "Browse All Charts" button exists
+    const browseLink = page.getByRole('link', { name: 'Browse All Charts' })
+    await expect(browseLink).toBeVisible()
+
+    // Click and verify navigation
+    await browseLink.click()
+    await expect(page).toHaveURL(/\/charts\/browse/)
+  })
+
+  test('should handle empty state gracefully', async ({ page }) => {
+    await page.goto('/charts/browse')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Either charts grid or empty state should be visible
+    const chartsGrid = page.locator('.grid')
+    const emptyState = page.getByText('No charts found')
+
+    // One of these should be visible (depending on whether there are charts)
+    const gridVisible = await chartsGrid.isVisible().catch(() => false)
+    const emptyVisible = await emptyState.isVisible().catch(() => false)
+
+    expect(gridVisible || emptyVisible).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #278 - allows browsing all charts ever created on the platform.

- Adds `/charts/browse` page with paginated grid of all chart thumbnails
- Sort options: newest, most viewed, recently accessed  
- Dynamic thumbnail generation showing chart title
- Admin-only "Saved By" indicator showing who saved each chart
- Link from gallery page header ("Browse All Charts" button)

## Changes

- `app/pages/charts/browse.vue` - New browse page with card grid
- `server/api/charts/browse.get.ts` - API endpoint with pagination & admin savedBy info
- `app/pages/charts/index.vue` - Added link button to browse page
- `tests/e2e/browse-charts.spec.ts` - E2E tests (25 tests across 5 browsers)

## Technical details

- Thumbnails use `/chart.png` with z=1.5 zoom for readable titles
- Deep links strip display-only params (ti, qr, l, cap, dm, etc.)
- Handles empty state and missing table gracefully

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)