### PR TITLE
fix: treat admin users as Pro tier for feature access

### DIFF
--- a/app/composables/useFeatureAccess.ts
+++ b/app/composables/useFeatureAccess.ts
@@ -28,12 +28,13 @@ import {
  */
 export function useFeatureAccess() {
   // Get user tier from auth composable
-  const { tier, isAuthenticated } = useAuth()
+  const { tier, isAuthenticated, isAdmin } = useAuth()
 
   // Computed tier helpers
   const isPublic = computed(() => tier.value === TIERS.PUBLIC)
   const isRegistered = computed(() => tier.value >= TIERS.REGISTERED)
-  const isPro = computed(() => tier.value >= TIERS.PRO)
+  // Admins always have Pro-level access regardless of stored tier
+  const isPro = computed(() => tier.value >= TIERS.PRO || isAdmin.value)
 
   /**
    * Check if user can access a specific feature

--- a/scripts/promote-admin.ts
+++ b/scripts/promote-admin.ts
@@ -31,7 +31,7 @@ if (user.role === 'admin') {
 
 await db
   .update(users)
-  .set({ role: 'admin', updatedAt: new Date() })
+  .set({ role: 'admin', tier: 2, updatedAt: new Date() })
   .where(eq(users.id, user.id))
 
-console.log(`✅ ${email} promoted to admin`)
+console.log(`✅ ${email} promoted to admin with Pro tier`)


### PR DESCRIPTION
## Summary
- Admins now correctly receive Pro-level feature access regardless of stored tier
- `promote-admin.ts` script now sets tier to 2 when promoting users
- Fixes Features tab appearing in wrong navbar position for admin users

## Test plan
- [ ] Log in as admin user with tier < 2
- [ ] Verify Features tab appears in secondary nav (same as Pro users)
- [ ] Verify all Pro features are accessible
- [ ] Run promote-admin script on a test user and verify tier is set to 2

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)