### PR TITLE
feat: Improve chart image alt text with metric details (Vibe Kanban)

### DIFF
--- a/app/components/discover/CountryChartCard.vue
+++ b/app/components/discover/CountryChartCard.vue
@@ -3,7 +3,7 @@
     :to="linkUrl"
     :thumbnail-url="thumbnailUrl"
     :locked-thumbnail-url="lockedThumbnailUrl"
-    :alt="`${countryName} chart`"
+    :alt="chartAlt"
     :label="countryName"
     :emoji="getFlagEmoji(country)"
     :locked="isLocked"
@@ -15,6 +15,7 @@
 import type { DiscoveryPreset } from '@/lib/discover/presets'
 import { presetToExplorerUrl, presetToThumbnailUrl } from '@/lib/discover/presets'
 import { getFlagEmoji } from '@/lib/discover/countryUtils'
+import { metricInfo, chartTypeLabels, viewLabels } from '@/lib/discover/constants'
 
 interface Props {
   preset: DiscoveryPreset
@@ -56,5 +57,13 @@ const lockedThumbnailUrl = computed(() => {
   return presetToThumbnailUrl(normalPreset, props.country, {
     darkMode: colorMode.value === 'dark'
   })
+})
+
+// Generate descriptive alt text for the chart image
+const chartAlt = computed(() => {
+  const metric = metricInfo[props.preset.metric].label
+  const chartType = chartTypeLabels[props.preset.chartType]
+  const view = viewLabels[props.preset.view]
+  return `${props.countryName} ${metric} ${chartType} ${view} chart`
 })
 </script>


### PR DESCRIPTION
## Summary

Improved the chart image alt text in the Discover page to provide more descriptive accessibility information.

### Changes Made

- Updated `CountryChartCard.vue` to generate descriptive alt text for chart thumbnails
- Added imports for `metricInfo`, `chartTypeLabels`, and `viewLabels` from the constants module
- Created a computed property that combines all relevant chart information

### Before & After

| Before | After |
|--------|-------|
| `"United States chart"` | `"United States Deaths Quarterly Excess chart"` |
| `"Sweden chart"` | `"Sweden Life Expectancy Yearly Raw Values chart"` |

### Alt Text Format

The new format is: `"{countryName} {metric} {chartType} {view} chart"`

This includes:
- **Country name** - e.g., "United States", "United Kingdom"
- **Metric label** - e.g., "Deaths", "Life Expectancy", "Age-Standardized Mortality Rate"
- **Chart type** - e.g., "Weekly", "Monthly", "Quarterly", "Yearly"
- **View type** - e.g., "Raw Values", "Excess", "Z-Score"

### Why This Matters

- **Accessibility**: Screen readers now provide meaningful context about what each chart displays
- **SEO**: Search engines can better understand and index chart images
- **User Experience**: Hover tooltips on images will show descriptive text

---

This PR was written using [Vibe Kanban](https://vibekanban.com)