### PR TITLE
refactor: Replace hardcoded support email with SUPPORT_EMAIL env variable (Vibe Kanban)

### DIFF
--- a/app/components/LegalPrivacy.vue
+++ b/app/components/LegalPrivacy.vue
@@ -2,6 +2,7 @@
 const config = useRuntimeConfig()
 const siteUrl = config.public.siteUrl || 'https://www.mortality.watch'
 const siteDomain = siteUrl.replace(/^https?:\/\//, '')
+const supportEmail = config.public.supportEmail
 </script>
 
 <template>
@@ -248,10 +249,10 @@ const siteDomain = siteUrl.replace(/^https?:\/\//, '')
         <p>
           To exercise any of these rights, please contact us at
           <ULink
-            to="mailto:mortalitywatch@proton.me"
+            :to="`mailto:${supportEmail}`"
             class="text-primary hover:underline"
           >
-            mortalitywatch@proton.me
+            {{ supportEmail }}
           </ULink>. We will respond to your request within 30 days (or as required by applicable law).
         </p>
         <p>
@@ -366,10 +367,10 @@ const siteDomain = siteUrl.replace(/^https?:\/\//, '')
           not knowingly collect personal information from children. If you believe we have collected
           information from a child, please contact us at
           <ULink
-            to="mailto:mortalitywatch@proton.me"
+            :to="`mailto:${supportEmail}`"
             class="text-primary hover:underline"
           >
-            mortalitywatch@proton.me
+            {{ supportEmail }}
           </ULink>, and we will promptly delete such information.
         </p>
       </div>
@@ -412,10 +413,10 @@ const siteDomain = siteUrl.replace(/^https?:\/\//, '')
         <p class="font-semibold">
           Email:
           <ULink
-            to="mailto:mortalitywatch@proton.me"
+            :to="`mailto:${supportEmail}`"
             class="text-primary hover:underline"
           >
-            mortalitywatch@proton.me
+            {{ supportEmail }}
           </ULink>
         </p>
         <p class="mt-4">

--- a/app/components/LegalRefund.vue
+++ b/app/components/LegalRefund.vue
@@ -1,3 +1,8 @@
+<script setup lang="ts">
+const config = useRuntimeConfig()
+const supportEmail = config.public.supportEmail
+</script>
+
 <template>
   <div class="space-y-6 text-gray-700 dark:text-gray-300">
     <UCard>
@@ -91,10 +96,10 @@
             <p>
               Send an email to
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline font-semibold"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>
               with the subject line "Refund Request".
             </p>
@@ -197,10 +202,10 @@
           If you were charged due to a billing error (e.g., duplicate charge, incorrect amount),
           we will issue a full refund regardless of the 30-day window. Please contact us at
           <ULink
-            to="mailto:mortalitywatch@proton.me"
+            :to="`mailto:${supportEmail}`"
             class="text-primary hover:underline"
           >
-            mortalitywatch@proton.me
+            {{ supportEmail }}
           </ULink>
           immediately if you notice a billing error.
         </p>
@@ -282,10 +287,10 @@
           your bank or card issuer, as processing times may vary. If the issue persists, contact
           us at
           <ULink
-            to="mailto:mortalitywatch@proton.me"
+            :to="`mailto:${supportEmail}`"
             class="text-primary hover:underline"
           >
-            mortalitywatch@proton.me
+            {{ supportEmail }}
           </ULink>.
         </p>
       </div>
@@ -342,10 +347,10 @@
           </p>
           <p>
             <ULink
-              to="mailto:mortalitywatch@proton.me"
+              :to="`mailto:${supportEmail}`"
               class="text-primary hover:underline text-lg font-semibold"
             >
-              mortalitywatch@proton.me
+              {{ supportEmail }}
             </ULink>
           </p>
           <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">

--- a/app/components/LegalTerms.vue
+++ b/app/components/LegalTerms.vue
@@ -2,6 +2,7 @@
 const config = useRuntimeConfig()
 const siteUrl = config.public.siteUrl || 'https://www.mortality.watch'
 const siteDomain = siteUrl.replace(/^https?:\/\//, '')
+const supportEmail = config.public.supportEmail
 </script>
 
 <template>
@@ -370,10 +371,10 @@ const siteDomain = siteUrl.replace(/^https?:\/\//, '')
         <p class="font-semibold">
           Email:
           <ULink
-            to="mailto:mortalitywatch@proton.me"
+            :to="`mailto:${supportEmail}`"
             class="text-primary hover:underline"
           >
-            mortalitywatch@proton.me
+            {{ supportEmail }}
           </ULink>
         </p>
       </div>

--- a/app/pages/features.vue
+++ b/app/pages/features.vue
@@ -125,7 +125,7 @@
             </h3>
           </template>
           <p class="text-sm text-gray-600 dark:text-gray-400">
-            Yes! Please contact us at mortalitywatch@proton.me with proof of your academic
+            Yes! Please contact us at {{ supportEmail }} with proof of your academic
             affiliation for special pricing.
           </p>
         </UCard>
@@ -165,6 +165,8 @@
 // Auth composable for user tier detection
 const { tier } = useAuth()
 const { trackSubscriptionView } = useAnalytics()
+const config = useRuntimeConfig()
+const supportEmail = config.public.supportEmail
 
 // Track features page view as subscription view
 onMounted(() => {

--- a/app/pages/legal/privacy.vue
+++ b/app/pages/legal/privacy.vue
@@ -251,10 +251,10 @@
             <p>
               To exercise any of these rights, please contact us at
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>. We will respond to your request within 30 days (or as required by applicable law).
             </p>
             <p>
@@ -369,10 +369,10 @@
               not knowingly collect personal information from children. If you believe we have collected
               information from a child, please contact us at
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>, and we will promptly delete such information.
             </p>
           </div>
@@ -415,10 +415,10 @@
             <p class="font-semibold">
               Email:
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>
             </p>
             <p class="mt-4">
@@ -436,6 +436,7 @@
 const config = useRuntimeConfig()
 const siteUrl = config.public.siteUrl || 'https://www.mortality.watch'
 const siteDomain = siteUrl.replace(/^https?:\/\//, '')
+const supportEmail = config.public.supportEmail
 
 // Page metadata
 definePageMeta({

--- a/app/pages/legal/refund.vue
+++ b/app/pages/legal/refund.vue
@@ -100,10 +100,10 @@
                 <p>
                   Send an email to
                   <ULink
-                    to="mailto:mortalitywatch@proton.me"
+                    :to="`mailto:${supportEmail}`"
                     class="text-primary hover:underline font-semibold"
                   >
-                    mortalitywatch@proton.me
+                    {{ supportEmail }}
                   </ULink>
                   with the subject line "Refund Request".
                 </p>
@@ -206,10 +206,10 @@
               If you were charged due to a billing error (e.g., duplicate charge, incorrect amount),
               we will issue a full refund regardless of the 30-day window. Please contact us at
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>
               immediately if you notice a billing error.
             </p>
@@ -291,10 +291,10 @@
               your bank or card issuer, as processing times may vary. If the issue persists, contact
               us at
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>.
             </p>
           </div>
@@ -351,10 +351,10 @@
               </p>
               <p>
                 <ULink
-                  to="mailto:mortalitywatch@proton.me"
+                  :to="`mailto:${supportEmail}`"
                   class="text-primary hover:underline text-lg font-semibold"
                 >
-                  mortalitywatch@proton.me
+                  {{ supportEmail }}
                 </ULink>
               </p>
               <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
@@ -380,6 +380,9 @@
 </template>
 
 <script setup lang="ts">
+const config = useRuntimeConfig()
+const supportEmail = config.public.supportEmail
+
 // Page metadata
 definePageMeta({
   title: 'Refund Policy'

--- a/app/pages/legal/terms.vue
+++ b/app/pages/legal/terms.vue
@@ -373,10 +373,10 @@
             <p class="font-semibold">
               Email:
               <ULink
-                to="mailto:mortalitywatch@proton.me"
+                :to="`mailto:${supportEmail}`"
                 class="text-primary hover:underline"
               >
-                mortalitywatch@proton.me
+                {{ supportEmail }}
               </ULink>
             </p>
           </div>
@@ -390,6 +390,7 @@
 const config = useRuntimeConfig()
 const siteUrl = config.public.siteUrl || 'https://www.mortality.watch'
 const siteDomain = siteUrl.replace(/^https?:\/\//, '')
+const supportEmail = config.public.supportEmail
 
 // Page metadata
 definePageMeta({

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,7 +50,8 @@ export default defineNuxtConfig({
       dataCachePath: '.data/cache/mortality',
       siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://www.mortality.watch',
       stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY || '',
-      statsUrl: process.env.NUXT_PUBLIC_STATS_URL || 'https://stats.mortality.watch/'
+      statsUrl: process.env.NUXT_PUBLIC_STATS_URL || 'https://stats.mortality.watch/',
+      supportEmail: process.env.SUPPORT_EMAIL || 'mortalitywatch@proton.me'
     }
   },
 

--- a/server/api/contact.post.ts
+++ b/server/api/contact.post.ts
@@ -52,8 +52,9 @@ export default defineEventHandler(async (event) => {
 
   const { name, email, subject, message, chartUrl } = result.data
 
-  // Get support email from environment or use default
-  const supportEmail = process.env.SUPPORT_EMAIL || 'mortalitywatch@proton.me'
+  // Get support email from runtime config
+  const config = useRuntimeConfig()
+  const supportEmail = config.public.supportEmail
 
   // Build email body
   const emailBody = `


### PR DESCRIPTION
## Summary

Replaces all hardcoded `mortalitywatch@proton.me` email addresses with a configurable `SUPPORT_EMAIL` environment variable, making the support email easily changeable without code modifications.

## Changes Made

### Configuration
- Added `supportEmail` to `nuxt.config.ts` runtime config (public), reading from `SUPPORT_EMAIL` env var with fallback to default

### Server
- Updated `server/api/contact.post.ts` to use `useRuntimeConfig().public.supportEmail` instead of `process.env.SUPPORT_EMAIL`

### Legal Pages (3 files)
- `app/pages/legal/terms.vue` - 1 email reference
- `app/pages/legal/refund.vue` - 4 email references  
- `app/pages/legal/privacy.vue` - 3 email references

### Legal Components (3 files)
- `app/components/LegalTerms.vue` - 1 email reference
- `app/components/LegalRefund.vue` - 4 email references
- `app/components/LegalPrivacy.vue` - 3 email references

### Features Page
- `app/pages/features.vue` - 1 email reference (FAQ section)

## Why

- Centralizes email configuration in environment variables
- Makes it easy to change support email without code changes
- Follows existing pattern for other configurable values (siteUrl, etc.)
- The `SUPPORT_EMAIL` was already defined in `.env.example` but wasn't being used consistently

## Implementation Details

- Email is exposed via `runtimeConfig.public.supportEmail` so it's accessible in both server and client code
- All Vue templates use `{{ supportEmail }}` with dynamic `:to` bindings for mailto links
- Default fallback ensures the app works without explicit configuration

---

This PR was written using [Vibe Kanban](https://vibekanban.com)