### PR TITLE
chore: Update Umami analytics endpoint to ua.e7ad.cc (Vibe Kanban)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ SENTRY_DSN=
 # Umami Analytics
 # Get the website ID from your Umami dashboard after adding the site
 NUXT_UMAMI_ID=
-# Umami host URL
+# Umami host URL (defaults to https://ua.e7ad.cc)
 NUXT_UMAMI_HOST=https://ua.e7ad.cc
 
 # Stripe API keys

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ SENTRY_DSN=your_sentry_dsn
 
 # Umami Analytics (optional)
 NUXT_UMAMI_ID=your_website_id          # Get from Umami dashboard
-NUXT_UMAMI_HOST=https://ua.mortality.watch  # Your Umami instance URL
+NUXT_UMAMI_HOST=https://ua.e7ad.cc  # Your Umami instance URL
 
 # Stripe (for subscriptions)
 STRIPE_PUBLISHABLE_KEY=pk_test_... # or pk_live_... for production

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -98,12 +98,12 @@ export default defineNuxtConfig({
           'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
           'Content-Security-Policy': [
             'default-src \'self\'',
-            'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://s3.mortality.watch https://stats.mortality.watch https://ua.mortality.watch https://js.stripe.com https://static.cloudflareinsights.com',
+            'script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://s3.mortality.watch https://stats.mortality.watch https://ua.e7ad.cc https://js.stripe.com https://static.cloudflareinsights.com',
             'style-src \'self\' \'unsafe-inline\'',
             'img-src \'self\' data: https:',
             'font-src \'self\' data:',
             // Allow localhost for local stats API development and Umami analytics
-            'connect-src \'self\' https://s3.mortality.watch https://stats.mortality.watch https://ua.mortality.watch https://api.stripe.com http://localhost:*',
+            'connect-src \'self\' https://s3.mortality.watch https://stats.mortality.watch https://ua.e7ad.cc https://api.stripe.com http://localhost:*',
             'frame-src https://js.stripe.com',
             'child-src https://js.stripe.com'
           ].join('; ')
@@ -124,7 +124,7 @@ export default defineNuxtConfig({
   // Umami Analytics configuration
   umami: {
     id: process.env.NUXT_UMAMI_ID || '',
-    host: process.env.NUXT_UMAMI_HOST || 'https://ua.mortality.watch',
+    host: process.env.NUXT_UMAMI_HOST || 'https://ua.e7ad.cc',
     autoTrack: true,
     ignoreLocalhost: true,
     enabled: !!process.env.NUXT_UMAMI_ID


### PR DESCRIPTION
## Summary

Updates the Umami analytics endpoint from `ua.mortality.watch` to `ua.e7ad.cc` to allow the analytics instance to be shared across multiple projects.

## Changes

- **`.env.example`**: Updated default Umami host URL comment and value
- **`README.md`**: Updated example environment variable for Umami host
- **`nuxt.config.ts`**: 
  - Updated default Umami host fallback from `ua.mortality.watch` to `ua.e7ad.cc`
  - Updated Content-Security-Policy headers (`script-src` and `connect-src`) to allow the new analytics domain

## Why

The Umami analytics deployment is being moved to a shared domain (`ua.e7ad.cc`) so it can be reused across multiple projects, rather than being specific to mortality.watch.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)