### PR TITLE
fix: Rename password utils to avoid nuxt-auth-utils conflict

### DIFF
--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { db, users } from '#db'
 import { eq } from 'drizzle-orm'
 import {
-  hashPassword,
+  hashUserPassword,
   generateRandomToken,
   hashToken
 } from '../../utils/auth'
@@ -109,7 +109,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Hash password
-  const passwordHash = await hashPassword(password)
+  const passwordHash = await hashUserPassword(password)
 
   // Generate verification token
   const verificationToken = generateRandomToken()

--- a/server/api/auth/reset-password.post.ts
+++ b/server/api/auth/reset-password.post.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { db, users } from '#db'
 import { eq } from 'drizzle-orm'
-import { hashPassword, hashToken, generateToken, setAuthToken } from '../../utils/auth'
+import { hashUserPassword, hashToken, generateToken, setAuthToken } from '../../utils/auth'
 
 const resetPasswordSchema = z.object({
   token: z.string().min(1, 'Reset token is required'),
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Hash new password
-  const passwordHash = await hashPassword(password)
+  const passwordHash = await hashUserPassword(password)
 
   // Update user password, clear reset token, and verify email
   // If they can reset password via email, they control the email address

--- a/server/api/auth/signin.post.ts
+++ b/server/api/auth/signin.post.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { db, users } from '#db'
 import { eq } from 'drizzle-orm'
 import {
-  verifyPassword,
+  verifyUserPassword,
   generateToken,
   setAuthToken
 } from '../../utils/auth'
@@ -70,7 +70,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Verify password
-  const isValidPassword = await verifyPassword(password, user.passwordHash)
+  const isValidPassword = await verifyUserPassword(password, user.passwordHash)
 
   if (!isValidPassword) {
     throw createError({

--- a/server/api/user/account.delete.ts
+++ b/server/api/user/account.delete.ts
@@ -1,6 +1,6 @@
 import { db, users, subscriptions } from '#db'
 import { eq } from 'drizzle-orm'
-import { requireAuth, verifyPassword } from '../../utils/auth'
+import { requireAuth, verifyUserPassword } from '../../utils/auth'
 import { z } from 'zod'
 
 /**
@@ -45,7 +45,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Verify password before deletion (security measure)
-  const isPasswordValid = await verifyPassword(password, user.passwordHash)
+  const isPasswordValid = await verifyUserPassword(password, user.passwordHash)
   if (!isPasswordValid) {
     throw createError({
       statusCode: 401,

--- a/server/api/user/profile.patch.ts
+++ b/server/api/user/profile.patch.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { db, users } from '#db'
 import { eq } from 'drizzle-orm'
-import { requireAuth, hashPassword } from '../../utils/auth'
+import { requireAuth, hashUserPassword } from '../../utils/auth'
 import { ProfileUpdateResponseSchema } from '../../schemas'
 
 const updateProfileSchema = z.object({
@@ -123,7 +123,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Hash new password
-    updates.passwordHash = await hashPassword(newPassword)
+    updates.passwordHash = await hashUserPassword(newPassword)
   }
 
   // Update user

--- a/server/utils/auth.test.ts
+++ b/server/utils/auth.test.ts
@@ -106,81 +106,81 @@ describe('Auth Utilities', () => {
     process.env = originalEnv
   })
 
-  describe('hashPassword', () => {
+  describe('hashUserPassword', () => {
     it('should hash a password using bcrypt', async () => {
-      const { hashPassword } = await import('./auth')
+      const { hashUserPassword } = await import('./auth')
       const bcrypt = await import('bcryptjs')
 
       const password = 'MySecurePassword123!'
-      const hash = await hashPassword(password)
+      const hash = await hashUserPassword(password)
 
       expect(bcrypt.default.hash).toHaveBeenCalledWith(password, 12)
       expect(hash).toBe(`hashed_${password}`)
     })
 
     it('should use bcrypt with cost factor 12', async () => {
-      const { hashPassword } = await import('./auth')
+      const { hashUserPassword } = await import('./auth')
       const bcrypt = await import('bcryptjs')
 
-      await hashPassword('test')
+      await hashUserPassword('test')
 
       expect(bcrypt.default.hash).toHaveBeenCalledWith('test', 12)
     })
 
     it('should handle empty password', async () => {
-      const { hashPassword } = await import('./auth')
-      const hash = await hashPassword('')
+      const { hashUserPassword } = await import('./auth')
+      const hash = await hashUserPassword('')
 
       expect(hash).toBe('hashed_')
     })
 
     it('should handle special characters in password', async () => {
-      const { hashPassword } = await import('./auth')
+      const { hashUserPassword } = await import('./auth')
       const password = 'P@$$w0rd!#$%^&*()'
-      const hash = await hashPassword(password)
+      const hash = await hashUserPassword(password)
 
       expect(hash).toBe(`hashed_${password}`)
     })
   })
 
-  describe('verifyPassword', () => {
+  describe('verifyUserPassword', () => {
     it('should verify a correct password', async () => {
-      const { verifyPassword } = await import('./auth')
+      const { verifyUserPassword } = await import('./auth')
 
       const password = 'MySecurePassword123!'
       const hash = `hashed_${password}`
-      const result = await verifyPassword(password, hash)
+      const result = await verifyUserPassword(password, hash)
 
       expect(result).toBe(true)
     })
 
     it('should reject an incorrect password', async () => {
-      const { verifyPassword } = await import('./auth')
+      const { verifyUserPassword } = await import('./auth')
 
-      const result = await verifyPassword('wrong', 'hashed_correct')
+      const result = await verifyUserPassword('wrong', 'hashed_correct')
 
       expect(result).toBe(false)
     })
 
     it('should handle empty password verification', async () => {
-      const { verifyPassword } = await import('./auth')
+      const { verifyUserPassword } = await import('./auth')
 
-      const result = await verifyPassword('', 'hashed_password')
+      const result = await verifyUserPassword('', 'hashed_password')
 
       expect(result).toBe(false)
     })
 
     it('should be timing-safe against timing attacks', async () => {
-      const { verifyPassword } = await import('./auth')
+      const { verifyUserPassword } = await import('./auth')
       const bcrypt = await import('bcryptjs')
 
       // Verify that bcrypt.compare is always called (timing-safe)
-      await verifyPassword('test', 'hashed_test')
+      await verifyUserPassword('test', 'hashed_test')
       expect(bcrypt.default.compare).toHaveBeenCalled()
 
       vi.clearAllMocks()
 
-      await verifyPassword('wrong', 'hashed_test')
+      await verifyUserPassword('wrong', 'hashed_test')
       expect(bcrypt.default.compare).toHaveBeenCalled()
     })
   })
@@ -1218,20 +1218,20 @@ describe('Auth Utilities', () => {
     })
 
     it('should handle unicode characters in passwords', async () => {
-      const { hashPassword, verifyPassword } = await import('./auth')
+      const { hashUserPassword, verifyUserPassword } = await import('./auth')
 
       const unicodePassword = 'パスワード123!🔒'
-      const hash = await hashPassword(unicodePassword)
-      const isValid = await verifyPassword(unicodePassword, hash)
+      const hash = await hashUserPassword(unicodePassword)
+      const isValid = await verifyUserPassword(unicodePassword, hash)
 
       expect(isValid).toBe(true)
     })
 
     it('should handle null bytes in password', async () => {
-      const { hashPassword } = await import('./auth')
+      const { hashUserPassword } = await import('./auth')
 
       const passwordWithNull = 'password\x00malicious'
-      const hash = await hashPassword(passwordWithNull)
+      const hash = await hashUserPassword(passwordWithNull)
 
       expect(hash).toBeDefined()
     })
@@ -1277,15 +1277,15 @@ describe('Auth Utilities', () => {
 
   describe('Integration Scenarios', () => {
     it('should handle full authentication flow: hash -> generate token -> verify -> get user', async () => {
-      const { hashPassword, verifyPassword, generateToken, verifyToken, getCurrentUser } = await import('./auth')
+      const { hashUserPassword, verifyUserPassword, generateToken, verifyToken, getCurrentUser } = await import('./auth')
 
       // 1. Hash password
       const password = 'SecurePassword123!'
-      const hash = await hashPassword(password)
+      const hash = await hashUserPassword(password)
       expect(hash).toBe(`hashed_${password}`)
 
       // 2. Verify password
-      const isValid = await verifyPassword(password, hash)
+      const isValid = await verifyUserPassword(password, hash)
       expect(isValid).toBe(true)
 
       // 3. Generate token

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -97,12 +97,12 @@ function getJwtSecret(): string {
  *
  * @example
  * ```typescript
- * const hash = await hashPassword('user-password-123')
+ * const hash = await hashUserPassword('user-password-123')
  * // Returns: '$2a$12$...' (60 characters)
  * // Store this hash in database, never the plain password
  * ```
  */
-export async function hashPassword(password: string): Promise<string> {
+export async function hashUserPassword(password: string): Promise<string> {
   return await bcrypt.hash(password, 12)
 }
 
@@ -132,7 +132,7 @@ export async function hashPassword(password: string): Promise<string> {
  *
  * @example
  * ```typescript
- * const isValid = await verifyPassword('user-password-123', storedHash)
+ * const isValid = await verifyUserPassword('user-password-123', storedHash)
  * if (isValid) {
  *   // Password correct, proceed with login
  * } else {
@@ -140,7 +140,7 @@ export async function hashPassword(password: string): Promise<string> {
  * }
  * ```
  */
-export async function verifyPassword(
+export async function verifyUserPassword(
   password: string,
   hash: string
 ): Promise<boolean> {
@@ -528,7 +528,7 @@ export async function requireTier(event: H3Event, requiredTier: 0 | 1 | 2) {
  * // Returns: '3a7c9f2b1e4d8a6c...' (64 characters)
  *
  * // Store hashed version in database
- * const hashedToken = await hashPassword(resetToken)
+ * const hashedToken = await hashUserPassword(resetToken)
  * await db.update(users)
  *   .set({
  *     resetToken: hashedToken,
@@ -755,7 +755,7 @@ export async function handleSocialAuth(
       // Generate a random password hash for social users
       // They won't use it but the field is required
       const randomPassword = randomBytes(32).toString('hex')
-      const passwordHash = await hashPassword(randomPassword)
+      const passwordHash = await hashUserPassword(randomPassword)
 
       user = await db
         .insert(users)


### PR DESCRIPTION
## Summary
- Rename `hashPassword` → `hashUserPassword` and `verifyPassword` → `verifyUserPassword`
- Eliminates duplicated imports warning from nuxt-auth-utils module
- Updates all call sites and tests

## Test plan
- [x] Typecheck passes
- [x] All 70 auth tests pass
- [x] E2E auth tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)