### PR TITLE
feat: Add visual tints to discover page cards for N/A and error states (Vibe Kanban)

### DIFF
--- a/app/components/discover/PresetsMatrix.vue
+++ b/app/components/discover/PresetsMatrix.vue
@@ -99,7 +99,6 @@
           </NuxtLink>
 
           <!-- Placeholder for unavailable metric/chartType combinations (gray tint) -->
-          <!-- Note: Failed charts are hidden entirely, not shown as placeholders -->
           <div
             v-else-if="!isChartFailed(metric, chartType)"
             class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 bg-gray-100/50 dark:bg-gray-800/30 overflow-hidden"
@@ -117,6 +116,29 @@
               style="aspect-ratio: 16/9"
             >
               <span class="text-xs text-gray-400 dark:text-gray-500 text-center px-4">
+                {{ getUnavailableReason(metric, chartType) }}
+              </span>
+            </div>
+          </div>
+
+          <!-- Placeholder for failed/error charts (subtle red tint) -->
+          <div
+            v-else
+            class="rounded-lg border border-dashed border-red-300 dark:border-red-900/60 bg-red-50/30 dark:bg-red-950/20 overflow-hidden"
+          >
+            <!-- Header with title -->
+            <div class="px-3 py-2 text-center border-b border-dashed border-red-300 dark:border-red-900/60">
+              <h4 class="text-sm font-semibold text-red-400 dark:text-red-700">
+                {{ metricInfo[metric].label }}
+              </h4>
+            </div>
+
+            <!-- Placeholder content -->
+            <div
+              class="flex items-center justify-center bg-red-100/20 dark:bg-red-900/10"
+              style="aspect-ratio: 16/9"
+            >
+              <span class="text-xs text-red-400 dark:text-red-600 text-center px-4">
                 {{ getUnavailableReason(metric, chartType) }}
               </span>
             </div>


### PR DESCRIPTION
## Summary

Add subtle color tints to placeholder cards on the discover pages to differentiate between unavailable metrics and failed/error charts:

- **Gray tint** - For N/A metrics (e.g., "Population only available in Raw Values view", "Only available for yearly periods")
- **Red tint** - For failed/error charts that should be available but failed to load (e.g., "Chart data unavailable")

## Why

Previously, all placeholder cards looked identical regardless of why they were shown. This made it difficult to distinguish between:
1. Metrics that are legitimately unavailable for a given view/period combination
2. Charts that failed to load due to missing data or errors

The red tint for error states helps identify charts that may need attention or could be disabled if they are rightfully empty.

## Implementation Details

- Modified `PresetsMatrix.vue` to use a three-way conditional:
  - `v-if` - Valid charts (shown normally)
  - `v-else-if="!isChartFailed(...)"` - N/A metrics (gray tint)
  - `v-else` - Failed charts (red tint)
- Used subtle opacity values (`/30`, `/20`, `/50`) to keep tints non-intrusive
- Full dark mode support for both tint variants

## Preview

https://next.mortality.watch/discover/country/DEU

---

This PR was written using [Vibe Kanban](https://vibekanban.com)