### PR TITLE
feat: Add loading placeholder while chart image loads (Vibe Kanban)

### DIFF
--- a/app/pages/charts/[slug].vue
+++ b/app/pages/charts/[slug].vue
@@ -301,7 +301,6 @@ const slug = route.params.slug as string
 
 // Track image loading state - reset when URL changes (e.g., color mode toggle)
 const imageLoaded = ref(false)
-const currentImageUrl = ref<string | null>(null)
 
 // Fetch chart data
 const { data: chart, pending, error } = await useFetch<Chart>(
@@ -397,11 +396,8 @@ const chartImageUrl = computed(() => {
 })
 
 // Reset loading state when chart image URL changes (e.g., color mode toggle)
-watch(chartImageUrl, (newUrl) => {
-  if (newUrl !== currentImageUrl.value) {
-    imageLoaded.value = false
-    currentImageUrl.value = newUrl
-  }
+watch(chartImageUrl, () => {
+  imageLoaded.value = false
 })
 
 // Absolute URL version for OG meta tags


### PR DESCRIPTION
## Summary

Added a loading placeholder with skeleton animation and spinner to the chart page (`/charts/[slug]`) that displays while the chart image is loading. This provides visual feedback to users, making the page feel more responsive.

## Changes

- **Loading placeholder**: Added an animated pulse background with a spinning loader icon that displays while the chart image loads
- **Image load tracking**: Implemented `imageLoaded` state that tracks when the image has finished loading via `@load` and `@error` events
- **Color mode support**: Added a watcher that resets the loading state when the chart URL changes (e.g., when toggling dark/light mode), ensuring the placeholder shows again while the new themed image loads
- **SSR hydration handling**: Wrapped the image in `ClientOnly` with a `#fallback` template to handle server-side rendering correctly
- **Layout stability**: Used fixed aspect ratio (2:1) container to prevent layout shift during image loading

## Implementation Details

The implementation follows existing patterns in the codebase used by `ChartCard.vue` and `discover/Thumbnail.vue`:
- Uses `ClientOnly` wrapper for proper SSR/hydration handling
- Uses `:key` binding on the image to force Vue to remount when URL changes
- Uses opacity transition for smooth image reveal

## Testing

Visit any chart page (e.g., `/charts/[any-chart-slug]`) and observe:
1. Loading placeholder appears while image loads
2. Image smoothly appears when loaded
3. Toggling color mode shows placeholder again while new image loads

Closes #404

---
This PR was written using [Vibe Kanban](https://vibekanban.com)