### PR TITLE
fix: Resolve chart.png rendering failures for ASMR charts

### DIFF
--- a/server/utils/chartPngHelpers.ts
+++ b/server/utils/chartPngHelpers.ts
@@ -45,11 +45,25 @@ export function getClientIp(event: H3Event): string {
 
 /**
  * Parse query parameters from request
+ * Handles URL encoding: converts + signs to spaces (form-encoded compatibility)
  * @param query - Raw query parameters
- * @returns Parsed query parameters
+ * @returns Parsed query parameters with + decoded as spaces
  */
 export function parseQueryParams(query: Record<string, unknown>): Record<string, string | string[]> {
-  return query as Record<string, string | string[]>
+  const result: Record<string, string | string[]> = {}
+
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === 'string') {
+      // Decode + as space for form-encoded URL compatibility
+      result[key] = value.replace(/\+/g, ' ')
+    } else if (Array.isArray(value)) {
+      result[key] = value.map(v => typeof v === 'string' ? v.replace(/\+/g, ' ') : String(v))
+    } else if (value !== null && value !== undefined) {
+      result[key] = String(value)
+    }
+  }
+
+  return result
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #409 - Chart preview image failing to load on homepage.

- **URL encoding fix**: The `+` character in URLs (e.g., `df=2020+W01`) was not being decoded as a space, causing date parsing failures
- **Data alignment fix**: For ASMR chart types, data arrays were not aligned with labels, causing index mismatches during filtering that resulted in empty datasets

## Root Cause

Two separate issues:

1. H3's `getQuery` follows URL spec where `+` is literal, not a space (unlike form-encoded data where `+` = space)
2. The labels array only included dates where `asmr_who` was defined (575 labels), but data arrays included ALL dates from the sliced range (1410 entries), causing index misalignment

## Test plan

- [ ] Test the broken URL: `https://next.mortality.watch/chart.png?c=USA&ct=weekly&df=2020+W01&dt=2024+W52&ti=0&qr=0&l=0&cap=0&dp=2&z=1.33&width=352&height=198`
- [ ] Test explorer still works: `https://next.mortality.watch/explorer?c=USA&ct=weekly&df=2020%20W01&dt=2024%20W52`
- [ ] Verify chart.png works with both `+` and `%20` encoding for spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)