### PR TITLE
fix: Hide unavailable chart types on discover metric pages

### DIFF
--- a/app/lib/discover/presets.test.ts
+++ b/app/lib/discover/presets.test.ts
@@ -107,9 +107,12 @@ describe('presets', () => {
   })
 
   describe('getPresetCountByMetric', () => {
-    it('should return 18 for non-population metrics', () => {
-      expect(getPresetCountByMetric('le')).toBe(18)
-      expect(getPresetCountByMetric('asd')).toBe(18)
+    it('should return correct count based on metric-chartType validity', () => {
+      // LE: only yearly (1 chartType × 3 views = 3)
+      expect(getPresetCountByMetric('le')).toBe(3)
+      // ASD: only yearly chart types (yearly, midyear, fluseason = 3 chartTypes × 3 views = 9)
+      expect(getPresetCountByMetric('asd')).toBe(9)
+      // ASMR, CMR, Deaths: all chart types (6 chartTypes × 3 views = 18)
       expect(getPresetCountByMetric('asmr')).toBe(18)
       expect(getPresetCountByMetric('cmr')).toBe(18)
       expect(getPresetCountByMetric('deaths')).toBe(18)

--- a/app/lib/discover/presets.ts
+++ b/app/lib/discover/presets.ts
@@ -81,12 +81,15 @@ export function getPresetsByMetric(metric: Metric): DiscoveryPreset[] {
 }
 
 /**
- * Get preset count for a metric
+ * Get preset count for a metric (accounts for metric-chartType validity)
  */
 export function getPresetCountByMetric(metric: Metric): number {
-  // Population: only normal view (1 view × 6 chart types)
-  // Others: all views (3 views × 6 chart types)
-  return metric === 'population' ? chartTypes.length : chartTypes.length * views.length
+  // Get valid chart types for this metric
+  const validChartTypeCount = chartTypes.filter(ct => isMetricValidForChartType(metric, ct)).length
+
+  // Population: only normal view (1 view × valid chart types)
+  // Others: all views (3 views × valid chart types)
+  return metric === 'population' ? validChartTypeCount : validChartTypeCount * views.length
 }
 
 /**

--- a/app/pages/discover/metric/[metric]/index.vue
+++ b/app/pages/discover/metric/[metric]/index.vue
@@ -54,7 +54,7 @@
     <!-- Preset Grid grouped by Chart Type -->
     <div class="space-y-8">
       <div
-        v-for="chartType in chartTypes"
+        v-for="chartType in validChartTypes"
         :key="chartType"
       >
         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">
@@ -116,10 +116,12 @@
 import {
   type Metric,
   type View,
+  type ChartType,
   chartTypes,
   views,
   isValidMetric,
-  getPresetCountByMetric
+  getPresetCountByMetric,
+  isMetricValidForChartType
 } from '@/lib/discover/presets'
 import {
   metricInfo,
@@ -146,6 +148,12 @@ onMounted(() => {
   if (!isValidMetric(metric.value)) {
     router.replace('/discover/metric')
   }
+})
+
+// Filter chart types to only show those valid for this metric
+const validChartTypes = computed<ChartType[]>(() => {
+  if (!isValidMetric(metric.value)) return []
+  return chartTypes.filter(ct => isMetricValidForChartType(metric.value as Metric, ct))
 })
 
 // Computed properties


### PR DESCRIPTION
Filter chart types based on metric validity so that:
- LE (Life Expectancy) only shows yearly (1 chart type)
- ASD only shows yearly chart types (yearly, midyear, fluseason)

Also updates getPresetCountByMetric() to return accurate counts reflecting these restrictions.