### PR TITLE
fix: Update legacy site links to use old.mortality.watch subdomain

### DIFF
--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -238,7 +238,7 @@
         <p class="text-gray-700 dark:text-gray-300">
           Discover more:
           <ULink
-            to="https://www.mortality.watch/charts/list.html"
+            to="https://old.mortality.watch/charts/list.html"
             target="_blank"
             title="More Charts"
             active-class="text-primary"
@@ -248,7 +248,7 @@
           </ULink>
           ·
           <ULink
-            to="https://www.mortality.watch/data/index.html"
+            to="https://old.mortality.watch/data/index.html"
             target="_blank"
             title="Chart Data"
             active-class="text-primary"


### PR DESCRIPTION
## Summary
- Updates Charts and Data links in the About page to point to `old.mortality.watch` instead of `www.mortality.watch`
- Fixes 404 errors since these static HTML files are served from the legacy site

## Test plan
- [ ] Visit /about page and verify the Charts and Data links work correctly
- [ ] Confirm links open `old.mortality.watch/charts/list.html` and `old.mortality.watch/data/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)