### PR TITLE
fix: Allow UK regional codes in API path validation

### DIFF
--- a/server/api/data/[...path].ts
+++ b/server/api/data/[...path].ts
@@ -10,7 +10,8 @@ const CACHE_DIR = CACHE_CONFIG.MORTALITY_DATA_DIR
 // - {country}/{chartType}.csv (e.g., USA/weekly.csv)
 // - {country}/{chartType}_{ageGroup}.csv (e.g., USA/weekly_0-14.csv, USA/weekly_85+.csv)
 // - {jurisdiction}/{chartType}.csv (e.g., USA-FL/weekly.csv for sub-country jurisdictions)
-const VALID_PATH_PATTERN = /^(?:world_meta\.csv|[A-Z]{2,3}(?:-[A-Z]{2,3})?\/[a-z]+(?:_[\w+-]+)?\.csv)$/
+// - UK regional codes: GBRTENW (England & Wales), GBR_SCO (Scotland), GBR_NIR (Northern Ireland)
+const VALID_PATH_PATTERN = /^(?:world_meta\.csv|(?:[A-Z]{2,3}(?:-[A-Z]{2,3})?|GBR(?:TENW|_[A-Z]{3}))\/[a-z]+(?:_[\w+-]+)?\.csv)$/
 
 /**
  * Validates and sanitizes the path parameter to prevent path traversal attacks.

--- a/server/api/data/path-validation.test.ts
+++ b/server/api/data/path-validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 // Test the path validation regex pattern
-const VALID_PATH_PATTERN = /^(?:world_meta\.csv|[A-Z]{2,3}(?:-[A-Z]{2,3})?\/[a-z]+(?:_[\w+-]+)?\.csv)$/
+const VALID_PATH_PATTERN = /^(?:world_meta\.csv|(?:[A-Z]{2,3}(?:-[A-Z]{2,3})?|GBR(?:TENW|_[A-Z]{3}))\/[a-z]+(?:_[\w+-]+)?\.csv)$/
 
 describe('data path validation', () => {
   describe('valid paths', () => {
@@ -37,6 +37,19 @@ describe('data path validation', () => {
       expect(VALID_PATH_PATTERN.test('CAN-ON/yearly.csv')).toBe(true)
       expect(VALID_PATH_PATTERN.test('USA-FL/weekly_0-14.csv')).toBe(true)
       expect(VALID_PATH_PATTERN.test('USA-CA/weekly_85+.csv')).toBe(true)
+    })
+
+    it('should accept UK regional codes', () => {
+      expect(VALID_PATH_PATTERN.test('GBRTENW/weekly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBRTENW/yearly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBRTENW/fluseason.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBRTENW/weekly_0-14.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBRTENW/weekly_85+.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR_SCO/weekly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR_SCO/yearly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR_SCO/fluseason_15-64.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR_NIR/monthly.csv')).toBe(true)
+      expect(VALID_PATH_PATTERN.test('GBR_NIR/yearly_65-74.csv')).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary
- Fixed path validation regex to accept UK regional codes (GBRTENW, GBR_SCO, GBR_NIR)
- Added test coverage for UK regional code paths

The regex was only allowing 2-3 character country codes, which blocked requests for UK regional data despite it existing on S3.

Fixes #440

## Test plan
- [x] Path validation tests pass (16 tests)
- [ ] Verify England and Scotland data loads in Explorer: https://www.mortality.watch/explorer?c=SWE&c=GBRTENW&c=GBR_SCO&t=le&df=2006/07&dt=2023/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)