### PR TITLE
Cumulative excess calculation broken (vibe-kanban)

### DIFF
--- a/app/lib/chart/chartViews/excess.ts
+++ b/app/lib/chart/chartViews/excess.ts
@@ -76,7 +76,7 @@ export const EXCESS_VIEW: ChartViewConfig = {
         return ctx.cumulative ? 'Cum. Excess Deaths' : 'Excess Deaths'
       case 'cmr':
       case 'asmr':
-        return ctx.cumulative ? 'Cum. Excess per 100k' : 'Excess Deaths per 100k'
+        return ctx.cumulative ? 'Cum. Excess Deaths per 100k' : 'Excess Deaths per 100k'
       case 'asd':
         return ctx.cumulative ? 'Cum. Excess Deaths' : 'Excess Deaths'
       case 'le':


### PR DESCRIPTION
There appears to be an issue with how the uncumulative/cumulative toggle has been implemented.

**Reproduction URL:**
https://www.mortality.watch/explorer?e=1&c=SWE&c=FRA&df=2014/15&dt=2024/25&bf=2014/15&bt=2018/19&bm=lin_reg&ce=1&m=1&p=0

**Screenshot:**
<img width="1200" height="676" alt="Cumulative excess display issue" src="https://github.com/user-attachments/assets/32f7648b-e01f-4883-ad81-812a47d671f9" />

Closes #432