### PR TITLE
fix: resolve chart canvas defaulting to 300x150 on initial render

### DIFF
--- a/app/components/charts/MortalityChart.vue
+++ b/app/components/charts/MortalityChart.vue
@@ -220,7 +220,10 @@ watch(() => colorMode.value, async () => {
 })
 
 // Setup ResizeObserver to force chart updates when container resizes
-onMounted(() => {
+onMounted(async () => {
+  // Wait for vue-chartjs to finish rendering and container layout to settle
+  await nextTick()
+
   // Get the chart canvas container
   const chartCanvas = document.querySelector('#chart')
   if (!chartCanvas || !chartCanvas.parentElement) {
@@ -231,6 +234,12 @@ onMounted(() => {
 
   // Update initial chart width for auto-hide label logic
   chartWidth.value = parentContainer.offsetWidth || 800
+
+  // Force chart to recalculate size from container (fixes default 300x150 canvas)
+  const activeChart = getActiveChart()
+  if (activeChart?.chart) {
+    activeChart.chart.resize()
+  }
 
   let resizeTimeout: ReturnType<typeof setTimeout> | null = null
   const resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
## Summary

- Fix chart `<canvas>` rendering at HTML default dimensions (300×150px) on initial load
- Add `await nextTick()` in `onMounted` so vue-chartjs finishes rendering before we query the DOM
- Call `chart.resize()` immediately after mount to force Chart.js to read actual container dimensions

## Root cause

vue-chartjs creates the Chart.js instance in its own `onMounted` hook, which fires before the parent component's `onMounted`. At that point the canvas gets HTML defaults (300×150). Chart.js has `responsive: true`, but the initial render still flashes at the wrong size because the container layout hasn't settled yet.

## Test plan

- [ ] Verify chart renders at correct container size on first load (no 300×150 flash)
- [ ] Verify chart still resizes correctly on window resize
- [ ] Verify chart updates correctly on dark/light mode toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)