### PR TITLE
feat: switch selects to USelectMenu with chip badges

### DIFF
--- a/app/components/charts/MortalityChartControlsPrimary.vue
+++ b/app/components/charts/MortalityChartControlsPrimary.vue
@@ -135,6 +135,16 @@ const handleCountryChange = (val: SelectValue) => {
   }
 }
 
+const removeCountry = (value: string) => {
+  const filtered = props.countries.filter(c => c !== value)
+  emit('countriesChanged', filtered)
+}
+
+const removeAgeGroup = (value: string) => {
+  const filtered = props.ageGroups.filter(ag => ag !== value)
+  emit('ageGroupsChanged', filtered)
+}
+
 const handleAgeGroupChange = (val: SelectValue) => {
   const ageGroups = extractStringValues(val)
   selectedAgeGroups.value = ageGroups
@@ -180,17 +190,42 @@ const options = computed(() => {
       help-title="Data Availability"
       :help-warning="props.isAsmrType || props.isLifeExpectancyType"
     >
-      <UInputMenu
+      <USelectMenu
         v-model="selectedCountries"
         :items="options"
         multiple
-        searchable
         size="sm"
         class="flex-1"
-        delete-icon="i-lucide-x"
+        clear
         :disabled="props.isUpdating"
+        :ui="{ base: 'h-auto min-h-8 py-1' }"
         @update:model-value="handleCountryChange"
       >
+        <template #default="{ modelValue }">
+          <div
+            v-if="modelValue?.length"
+            class="flex flex-wrap gap-0.5"
+          >
+            <UBadge
+              v-for="item in modelValue"
+              :key="typeof item === 'string' ? item : item.value"
+              size="xs"
+              variant="subtle"
+              color="neutral"
+            >
+              {{ typeof item === 'string' ? item : item.label }}
+              <UIcon
+                name="i-lucide-x"
+                class="ml-0.5 size-3 cursor-pointer opacity-60 hover:opacity-100"
+                @click.stop="removeCountry(typeof item === 'string' ? item : item.value)"
+              />
+            </UBadge>
+          </div>
+          <span
+            v-else
+            class="text-dimmed"
+          >Select jurisdictions</span>
+        </template>
         <template #item-leading="{ item }">
           <UBadge
             v-if="item && typeof item === 'object' && 'chip' in item && item.chip"
@@ -201,7 +236,7 @@ const options = computed(() => {
             {{ (item.chip as { text: string }).text }}
           </UBadge>
         </template>
-      </UInputMenu>
+      </USelectMenu>
       <template #help>
         <div class="space-y-3">
           <!-- Warning for restricted views -->
@@ -264,18 +299,44 @@ const options = computed(() => {
       v-if="!props.isAsmrType && !props.isAsdType && (!props.isLifeExpectancyType || canAdvancedLE)"
       label="Age Groups"
     >
-      <UInputMenu
+      <USelectMenu
         v-model="selectedAgeGroups"
         :items="ageGroupOptions"
         placeholder="Select age groups"
         multiple
-        searchable
         size="sm"
         class="flex-1"
-        delete-icon="i-lucide-x"
+        clear
         :disabled="props.isUpdating"
+        :ui="{ base: 'h-auto min-h-8 py-1' }"
         @update:model-value="handleAgeGroupChange"
-      />
+      >
+        <template #default="{ modelValue }">
+          <div
+            v-if="modelValue?.length"
+            class="flex flex-wrap gap-0.5"
+          >
+            <UBadge
+              v-for="item in modelValue"
+              :key="typeof item === 'string' ? item : item.value"
+              size="xs"
+              variant="subtle"
+              color="neutral"
+            >
+              {{ typeof item === 'string' ? item : item.label }}
+              <UIcon
+                name="i-lucide-x"
+                class="ml-0.5 size-3 cursor-pointer opacity-60 hover:opacity-100"
+                @click.stop="removeAgeGroup(typeof item === 'string' ? item : item.value)"
+              />
+            </UBadge>
+          </div>
+          <span
+            v-else
+            class="text-dimmed"
+          >Select age groups</span>
+        </template>
+      </USelectMenu>
     </UiControlRow>
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Replace `UInputMenu` with `USelectMenu` for both Jurisdictions and Age Groups selects
- Selected items now display as neutral chip badges with individual X remove buttons
- Add `clear` prop for one-click clear-all functionality
- Trigger height auto-expands when chips wrap to multiple lines

## Why

`USelectMenu` opens on click (no text input in trigger), which is a cleaner UX for fixed option lists. Chip badges are more scannable than comma-separated text and allow removing individual items without opening the dropdown.

## Test plan

- [ ] Verify Jurisdictions select opens on click, shows chips for selected items
- [ ] Verify individual chip X removes that jurisdiction
- [ ] Verify clear-all X clears all jurisdictions
- [ ] Verify Age Groups select has same chip behavior
- [ ] Verify ASMR/CMR badges still show in jurisdiction dropdown items
- [ ] Verify country auto-removal toast still works when selecting incompatible age groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)