### PR TITLE
fix: resolve chart collapsing to 300px after login

### DIFF
--- a/app/components/charts/MortalityChart.vue
+++ b/app/components/charts/MortalityChart.vue
@@ -232,6 +232,14 @@ onMounted(async () => {
 
   const parentContainer = chartCanvas.parentElement
 
+  // Wait for container to have a non-zero width (layout may not have settled
+  // after client-side navigation, e.g. after login redirect)
+  let retries = 0
+  while (parentContainer.offsetWidth === 0 && retries < 10) {
+    await new Promise(resolve => requestAnimationFrame(resolve))
+    retries++
+  }
+
   // Update initial chart width for auto-hide label logic
   chartWidth.value = parentContainer.offsetWidth || 800
 

--- a/app/components/explorer/ExplorerChartContainer.vue
+++ b/app/components/explorer/ExplorerChartContainer.vue
@@ -164,10 +164,10 @@ defineExpose({
   max-width: 100%; /* Ensure it doesn't exceed parent */
 }
 
-/* In Auto mode with resize enabled, card follows content size during drag */
-.chart-card.chart-card-resizable:not(.chart-card-resized).can-resize {
-  width: fit-content;
-}
+/* In Auto mode with resize enabled, keep width: 100% (NOT fit-content).
+   fit-content creates a circular dependency: card width depends on canvas size,
+   but Chart.js canvas size depends on container width → defaults to 300x150.
+   Once the user drags to resize, .chart-card-resized applies fit-content instead. */
 
 /* Ensure UCard body can shrink */
 .chart-card :deep(.overflow-hidden) {


### PR DESCRIPTION
## Summary
- Removed `width: fit-content` CSS override on `.chart-card` in auto mode when `canResize` (Pro user) is true — this created a circular dependency where the card width depended on canvas content size, but Chart.js reads canvas size from the container width, causing it to collapse to the 300x150 default
- Added a `requestAnimationFrame` retry loop in `MortalityChart.vue` `onMounted` to wait for the container to have a non-zero width before calling `chart.resize()`, handling edge cases where layout hasn't settled after client-side navigation (e.g. login redirect)

## Test plan
- [ ] Log in as Pro user and verify the chart renders at full size on `/explorer`
- [ ] Test in incognito: log in, navigate to explorer — chart should be full size
- [ ] Verify chart resize handle still works for Pro users (drag to resize in Custom mode)
- [ ] Verify non-Pro users see charts at full size (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)