### PR TITLE
Fix baseline caption to show friendly method names

### DIFF
--- a/app/lib/chart/chartViews/helpers.ts
+++ b/app/lib/chart/chartViews/helpers.ts
@@ -46,9 +46,11 @@ export function getBaselineDescription(
   baselineDateTo: string
 ): string {
   const methodNames: Record<string, string> = {
-    mean: 'Mean',
+    mean: 'Average',
     median: 'Median',
-    naive: 'Naive'
+    naive: 'Last Value',
+    lin_reg: 'Linear Regression',
+    exp: 'Exponential Smoothing (ETS)'
   }
 
   const methodName = methodNames[baselineMethod] || baselineMethod


### PR DESCRIPTION
Fixes explorer/chart caption showing raw baseline method keys like `lin_reg`.

### What changed
- Updated baseline caption mapping to show user-friendly names:
  - `naive` -> `Last Value`
  - `mean` -> `Average`
  - `lin_reg` -> `Linear Regression`
  - `exp` -> `Exponential Smoothing (ETS)`

### Result
Chart captions now display readable baseline labels instead of internal keys.
