### PR TITLE
Fix #481: safer default z-score mode for weekly/monthly/quarterly

### DIFF
--- a/app/composables/useChartDataFetcher.ts
+++ b/app/composables/useChartDataFetcher.ts
@@ -42,6 +42,7 @@ export interface ChartDataFetchConfig {
   baselineDateFrom?: string
   baselineDateTo?: string
   baselineStartIdx?: number
+  zScoreMode?: 'auto' | 'classic' | 'robust'
 
   // Date range - sliderStart defines the "from" offset for allChartData (layer 2)
   sliderStart?: string
@@ -247,7 +248,8 @@ export function useChartDataFetcher() {
         fetchConfig.onProgress ?? ((progress, total) => {
           updateProgress.value = Math.round((progress / total) * 100)
         }),
-        statsUrl
+        statsUrl,
+        fetchConfig.zScoreMode && fetchConfig.zScoreMode !== 'auto' ? fetchConfig.zScoreMode : undefined
       )
 
       isUpdating.value = false

--- a/app/composables/useExplorerDataOrchestration.ts
+++ b/app/composables/useExplorerDataOrchestration.ts
@@ -785,6 +785,9 @@ export function useExplorerDataOrchestration(
       baselineMethod: state.baselineMethod.value,
       baselineDateFrom: state.baselineDateFrom.value ?? baselineRange.value?.from,
       baselineDateTo: state.baselineDateTo.value ?? baselineRange.value?.to,
+      zScoreMode: route.query.zsm === 'classic' || route.query.zsm === 'robust'
+        ? route.query.zsm
+        : 'auto',
       baselineStartIdx: undefined,
       sliderStart: state.sliderStart.value,
       cumulative: helpers.showCumPi(),

--- a/app/lib/baseline/calculateBaseline.test.ts
+++ b/app/lib/baseline/calculateBaseline.test.ts
@@ -197,6 +197,65 @@ describe('calculateBaseline', () => {
     })
   })
 
+  describe('z-score mode behavior', () => {
+    it('uses robust z-scores by default for periodic chart types', async () => {
+      const deps = createMockDeps({
+        y: [100, 100, 100, 100, 100, 100],
+        lower: [null, null, null, null, null, null],
+        upper: [null, null, null, null, null, null],
+        zscore: [0, 0, 0, 0, 0, 0]
+      })
+
+      const data: DatasetEntry = {
+        deaths: [100, 102, 101, 100, 150, 99]
+      } as unknown as DatasetEntry
+
+      await calculateBaseline(
+        deps,
+        data,
+        ['2019 W01', '2019 W02', '2019 W03', '2019 W04', '2019 W05', '2019 W06'],
+        0,
+        4,
+        ['deaths', 'deaths_baseline', 'deaths_baseline_lower', 'deaths_baseline_upper'] as (keyof DatasetEntry)[],
+        'mean',
+        'weekly',
+        false
+      )
+
+      expect(data.deaths_zscore).toBeDefined()
+      expect((data.deaths_zscore as unknown[])[4]).not.toBe(0)
+    })
+
+    it('supports classic mode override for periodic chart types', async () => {
+      const deps = createMockDeps({
+        y: [100, 102, 101, 100, 150, 99],
+        lower: [null, null, null, null, null, null],
+        upper: [null, null, null, null, null, null],
+        zscore: [0, 0.1, -0.2, 0.3, 9.9, -0.1]
+      })
+
+      const data: DatasetEntry = {
+        deaths: [100, 102, 101, 100, 150, 99]
+      } as unknown as DatasetEntry
+
+      await calculateBaseline(
+        deps,
+        data,
+        ['2019 W01', '2019 W02', '2019 W03', '2019 W04', '2019 W05', '2019 W06'],
+        0,
+        4,
+        ['deaths', 'deaths_baseline', 'deaths_baseline_lower', 'deaths_baseline_upper'] as (keyof DatasetEntry)[],
+        'mean',
+        'weekly',
+        false,
+        undefined,
+        'classic'
+      )
+
+      expect(data.deaths_zscore).toEqual([0, 0.1, -0.2, 0.3, 9.9, -0.1])
+    })
+  })
+
   describe('auto method early return', () => {
     it('should return early for auto method without API call', async () => {
       const deps = createMockDeps({})

--- a/app/lib/chart/types.ts
+++ b/app/lib/chart/types.ts
@@ -82,6 +82,7 @@ export interface ChartStateSnapshot {
   baselineDateTo: string | undefined
   showBaseline: boolean
   baselineMethod: string
+  zScoreMode?: 'auto' | 'classic' | 'robust'
 
   // Display options
   cumulative: boolean
@@ -132,6 +133,7 @@ export interface ChartFilterConfig {
 
   // Baseline (effective values with defaults applied)
   baselineMethod: string
+  zScoreMode?: 'auto' | 'classic' | 'robust'
   baselineDateFrom: string
   baselineDateTo: string
   showBaseline: boolean

--- a/app/lib/data/aggregations.ts
+++ b/app/lib/data/aggregations.ts
@@ -29,7 +29,8 @@ export type BaselineCalculatorFn = (
   chartType: string,
   cumulative: boolean,
   progressCb?: (progress: number, total: number) => void,
-  statsUrl?: string
+  statsUrl?: string,
+  zScoreMode?: 'classic' | 'robust'
 ) => Promise<void>
 
 /**
@@ -58,7 +59,8 @@ export const getAllChartData = async (
   keys?: (keyof NumberEntryFields)[],
   progressCb?: (progress: number, total: number) => void,
   statsUrl?: string,
-  calculateBaselines: BaselineCalculatorFn = clientCalculateBaselines
+  calculateBaselines: BaselineCalculatorFn = clientCalculateBaselines,
+  zScoreMode?: 'classic' | 'robust'
 ): Promise<AllChartData> => {
   const data: Dataset = {}
   const ageGroups = ageGroupFilter ?? Object.keys(rawData || {})
@@ -192,7 +194,8 @@ export const getAllChartData = async (
       chartType,
       cumulative,
       progressCb,
-      statsUrl
+      statsUrl,
+      zScoreMode
     )
   }
 

--- a/app/lib/data/baselines.ts
+++ b/app/lib/data/baselines.ts
@@ -41,7 +41,8 @@ export const calculateBaselines = async (
   chartType: string,
   cumulative: boolean,
   progressCb?: (progress: number, total: number) => void,
-  statsUrl?: string
+  statsUrl?: string,
+  zScoreMode?: 'classic' | 'robust'
 ): Promise<void> => {
   return sharedCalculateBaselines(
     clientDeps,
@@ -54,6 +55,7 @@ export const calculateBaselines = async (
     chartType,
     cumulative,
     progressCb,
-    statsUrl
+    statsUrl,
+    zScoreMode
   )
 }

--- a/app/lib/state/config/fieldEncoders.ts
+++ b/app/lib/state/config/fieldEncoders.ts
@@ -45,6 +45,7 @@ export const stateFieldEncoders = {
   ageGroups: { key: 'ag', decode: decodeArray },
   showBaseline: { key: 'sb', encode: encodeBool, decode: decodeBool },
   baselineMethod: { key: 'bm' },
+  zScoreMode: { key: 'zsm' },
   cumulative: { key: 'ce', encode: encodeBool, decode: decodeBool },
   showTotal: { key: 'st', encode: encodeBool, decode: decodeBool },
   maximize: { key: 'm', encode: encodeBool, decode: decodeBool },

--- a/app/lib/state/resolution/resolveChartState.ts
+++ b/app/lib/state/resolution/resolveChartState.ts
@@ -45,6 +45,7 @@ export interface ChartRenderState {
   // Baseline (effective - never undefined when showBaseline is true)
   showBaseline: boolean
   baselineMethod: string
+  zScoreMode?: 'auto' | 'classic' | 'robust'
   baselineDateFrom: string
   baselineDateTo: string
 
@@ -238,6 +239,7 @@ export function resolveChartStateForRendering(
     // Baseline (effective values)
     showBaseline: constrainedState.showBaseline as boolean,
     baselineMethod: constrainedState.baselineMethod as string,
+    zScoreMode: (constrainedState.zScoreMode as 'auto' | 'classic' | 'robust' | undefined) ?? 'auto',
     baselineDateFrom: effectiveBaselineFrom,
     baselineDateTo: effectiveBaselineTo,
 
@@ -332,6 +334,7 @@ export function resolveChartStateFromSnapshot(
     sliderStart: snapshot.sliderStart || getDefaultSliderStart(),
     showBaseline: snapshot.showBaseline,
     baselineMethod: snapshot.baselineMethod,
+    zScoreMode: snapshot.zScoreMode ?? 'auto',
     baselineDateFrom: effectiveBaselineFrom,
     baselineDateTo: effectiveBaselineTo,
     ageGroups: snapshot.ageGroups,
@@ -484,6 +487,7 @@ export function toChartFilterConfig(
 
     // Baseline (already effective values)
     baselineMethod: state.baselineMethod,
+    zScoreMode: state.zScoreMode,
     baselineDateFrom: state.baselineDateFrom,
     baselineDateTo: state.baselineDateTo,
     showBaseline: state.showBaseline,

--- a/server/services/dataLoader.ts
+++ b/server/services/dataLoader.ts
@@ -58,6 +58,7 @@ export interface ChartDataParams {
   baselineDateFrom?: string
   baselineDateTo?: string
   keys?: (keyof NumberEntryFields)[]
+  zScoreMode?: 'classic' | 'robust'
 }
 
 /**
@@ -324,7 +325,8 @@ export class DataLoaderService {
       baselineMethod,
       baselineDateFrom,
       baselineDateTo,
-      keys
+      keys,
+      zScoreMode
     } = params
 
     // Use shared function with server-side baseline calculator injected
@@ -343,7 +345,8 @@ export class DataLoaderService {
       keys,
       undefined, // progressCb - not used on server
       undefined, // statsUrl - uses default
-      calculateBaselines // Server-side baseline calculator
+      calculateBaselines, // Server-side baseline calculator
+      zScoreMode
     )
   }
 

--- a/server/utils/baselines.ts
+++ b/server/utils/baselines.ts
@@ -41,7 +41,8 @@ export const calculateBaselines = async (
   chartType: string,
   cumulative: boolean,
   progressCb?: (progress: number, total: number) => void,
-  statsUrl?: string
+  statsUrl?: string,
+  zScoreMode?: 'classic' | 'robust'
 ): Promise<void> => {
   return sharedCalculateBaselines(
     serverDeps,
@@ -54,6 +55,7 @@ export const calculateBaselines = async (
     chartType,
     cumulative,
     progressCb,
-    statsUrl
+    statsUrl,
+    zScoreMode
   )
 }

--- a/server/utils/chartPngHelpers.ts
+++ b/server/utils/chartPngHelpers.ts
@@ -383,7 +383,8 @@ export async function fetchChartData(state: ChartRenderState) {
     baselineMethod: state.baselineMethod,
     baselineDateFrom: state.baselineDateFrom,
     baselineDateTo: state.baselineDateTo,
-    keys: baseKeys
+    keys: baseKeys,
+    zScoreMode: state.zScoreMode && state.zScoreMode !== 'auto' ? state.zScoreMode : undefined
   })
 
   // Inject ASD data if type is 'asd'


### PR DESCRIPTION
## Summary
- add robust z-score calculation mode (median-centered, asymmetric MAD scaling)
- make robust mode the default for periodic series (weekly/monthly/quarterly)
- add advanced URL override `zsm=classic|robust` (classic preserves previous stats API z-score output)
- wire `zScoreMode` through client+SSR data loading paths
- add unit tests for robust default and classic override

## Notes
- backward compatible: non-periodic chart types remain classic by default
- existing URLs continue working; advanced mode only applies when `zsm` is provided
