### PR TITLE
Fix invite-code Pro upgrade not reflected in UI

### DIFF
--- a/app/components/InviteCodeCard.vue
+++ b/app/components/InviteCodeCard.vue
@@ -44,7 +44,7 @@ async function applyInviteCode() {
 
   applying.value = true
   try {
-    const result = await $fetch<{ success: boolean, message: string }>('/api/user/apply-invite-code', {
+    const result = await $fetch<{ success: boolean, message: string, user?: typeof user.value }>('/api/user/apply-invite-code', {
       method: 'POST',
       body: { code: inviteCode.value.trim() }
     })
@@ -56,8 +56,13 @@ async function applyInviteCode() {
         color: 'success'
       })
 
-      // Refresh user session to get updated tier
-      await refreshSession()
+      // Optimistically update local user tier immediately when API returns refreshed user
+      if (result.user) {
+        user.value = result.user
+      } else {
+        // Fallback to session refresh
+        await refreshSession()
+      }
 
       // Clear the form
       inviteCode.value = ''

--- a/server/api/user/apply-invite-code.post.ts
+++ b/server/api/user/apply-invite-code.post.ts
@@ -1,6 +1,8 @@
 import { ApplyInviteCodeSchema } from '../../schemas'
 import { applyInviteCodeToUser } from '../../utils/inviteCode'
 import { requireAuth } from '../../utils/auth'
+import { db, users } from '#db'
+import { eq } from 'drizzle-orm'
 
 /**
  * API endpoint for retroactive invite code application
@@ -30,8 +32,23 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Return fresh user data so UI can reflect tier immediately without relying on session refresh
+  const updatedUser = await db
+    .select()
+    .from(users)
+    .where(eq(users.id, user.id))
+    .get()
+
+  const safeUser = updatedUser
+    ? (() => {
+        const { passwordHash: _passwordHash, ...rest } = updatedUser
+        return rest
+      })()
+    : user
+
   return {
     success: true,
-    message: applyResult.message
+    message: applyResult.message,
+    user: safeUser
   }
 })


### PR DESCRIPTION
## Summary
Fixes the flow where invite code application reports success but account still appears FREE in UI.

## Changes
- `POST /api/user/apply-invite-code` now returns the refreshed user row after tier update
- Invite code UI applies returned `user` immediately for instant tier update
- Keeps existing `refreshSession()` fallback when needed

## Why
Users can see “Valid code / grants Pro” yet profile/features still render FREE until later refresh. Returning and applying fresh user data removes that stale-state gap.

## Validation
- API now returns `{ success, message, user }` after successful apply
- UI immediately reflects tier 2 after success
