### PR TITLE
Forward server errors to Sentry from Nitro error hook

### DIFF
--- a/server/plugins/error-handler.ts
+++ b/server/plugins/error-handler.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger'
+import { errorTracker } from '../utils/errorTracking'
 
 interface ErrorWithStatus extends Error {
   statusCode?: number
@@ -10,6 +11,16 @@ export default defineNitroPlugin((nitroApp) => {
     logger.error('Server error', error, {
       url: event?.path,
       statusCode: error.statusCode
+    })
+
+    errorTracker.captureError(error, {
+      tags: {
+        scope: 'nitro-error-hook'
+      },
+      extra: {
+        url: event?.path,
+        statusCode: error.statusCode || error.status || 500
+      }
     })
   })
 


### PR DESCRIPTION
## Summary
Ensures unhandled Nitro server errors are sent to Sentry (when `SENTRY_DSN` is configured).

## Changes
- Import `errorTracker` in `server/plugins/error-handler.ts`
- Capture errors from Nitro `error` hook with context tags/extras (url, status)
- Preserve existing logger behavior

## Why
Server logs show production errors, but they were not reliably appearing in Sentry. This routes the same errors into the centralized tracker.

## Validation
- Error hook now calls `errorTracker.captureError(...)`
- Works only when tracker is initialized with DSN; otherwise console logging remains
