### PR TITLE
Fix /api/_auth/session 500 (Empty password)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,4 +78,10 @@ NUXT_OAUTH_GOOGLE_CLIENT_SECRET=
 NUXT_OAUTH_X_CLIENT_ID=
 NUXT_OAUTH_X_CLIENT_SECRET=
 
-# Note: OAuth session encryption reuses JWT_SECRET (no separate key needed)
+# Session encryption secret for nuxt-auth-utils (`/api/_auth/session`)
+# REQUIRED in production. Must be a strong random string (32+ chars).
+# If unset, app falls back to JWT_SECRET for backward compatibility.
+NUXT_SESSION_PASSWORD=
+
+# JWT secret for signing auth_token JWTs (required in production)
+JWT_SECRET=

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,9 +36,14 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     // Server-side only config (not exposed to client)
-    // Reuse JWT_SECRET for nuxt-auth-utils session encryption
+    // nuxt-auth-utils requires a non-empty session password.
+    // Prefer dedicated NUXT_SESSION_PASSWORD, fallback to JWT_SECRET for backward compatibility.
     session: {
-      password: process.env.JWT_SECRET || ''
+      password: process.env.NUXT_SESSION_PASSWORD
+        || process.env.JWT_SECRET
+        || (process.env.NODE_ENV === 'development'
+          ? 'development-session-password-change-in-production-32chars'
+          : '')
     },
     mortalityDataS3Base: process.env.MORTALITY_DATA_S3_BASE || 'https://s3.mortality.watch/data/mortality',
     mortalityDataCacheDir: process.env.MORTALITY_DATA_CACHE_DIR || '.data/cache/mortality',


### PR DESCRIPTION
Fixes empty session password configuration by preferring NUXT_SESSION_PASSWORD, falling back to JWT_SECRET, and documenting both in .env.example.