### PR TITLE
Forward server errors to Sentry from Nitro error hook

### DIFF
--- a/server/plugins/error-handler.ts
+++ b/server/plugins/error-handler.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger'
+import { errorTracker } from '../utils/errorTracking'
 
 interface ErrorWithStatus extends Error {
   statusCode?: number
@@ -10,6 +11,16 @@ export default defineNitroPlugin((nitroApp) => {
     logger.error('Server error', error, {
       url: event?.path,
       statusCode: error.statusCode
+    })
+
+    errorTracker.captureError(error, {
+      tags: {
+        scope: 'nitro-error-hook'
+      },
+      extra: {
+        url: event?.path,
+        statusCode: error.statusCode || error.status || 500
+      }
     })
   })
 


### PR DESCRIPTION
Routes Nitro error hook events into errorTracker.captureError() with context so production server errors reach Sentry when DSN is configured.