### PR TITLE
Fix z-score chart title omitting active metric label

### DIFF
--- a/app/lib/chart/chartViews/zscore.ts
+++ b/app/lib/chart/chartViews/zscore.ts
@@ -14,10 +14,37 @@ import { getAgeGroupSuffix, getBaselineDescription } from './helpers'
  */
 export const ZSCORE_VIEW: ChartViewConfig = {
   /**
-   * Override: Z-Score specific title
+   * Override: Z-Score specific title — includes the active metric
+   * (Deaths / CMR / ASMR / ASD / LE / Population) so exports and
+   * shared screenshots remain unambiguous.
    */
   getTitleParts: (ctx: ChartContext) => {
-    return ['Z-Score Analysis', getAgeGroupSuffix(ctx.ageGroups)]
+    const parts: string[] = ['Z-Score']
+
+    switch (ctx.type) {
+      case 'population':
+        parts.push(`Population${getAgeGroupSuffix(ctx.ageGroups)}`)
+        break
+      case 'deaths':
+        parts.push(`Deaths${getAgeGroupSuffix(ctx.ageGroups)}`)
+        break
+      case 'cmr':
+        parts.push('Crude', `Mortality Rate${getAgeGroupSuffix(ctx.ageGroups)}`)
+        break
+      case 'asmr':
+        parts.push('Age-Standardized', 'Mortality Rate')
+        break
+      case 'asd':
+        parts.push('Age-Standardized', 'Deaths')
+        break
+      case 'le':
+        parts.push('Life Expectancy')
+        break
+      default:
+        parts.push(`Analysis${getAgeGroupSuffix(ctx.ageGroups)}`)
+    }
+
+    return parts
   },
 
   /**

--- a/app/lib/chart/labels.test.ts
+++ b/app/lib/chart/labels.test.ts
@@ -152,6 +152,35 @@ describe('labels', () => {
 
         expect(result.title.join(' ')).not.toContain('[')
       })
+
+      it('should include metric in z-score title for life expectancy', () => {
+        const result = callGetChartLabels({ type: 'le', view: 'zscore' })
+
+        const title = result.title.join(' ')
+        expect(title).toContain('Z-Score')
+        expect(title).toContain('Life Expectancy')
+      })
+
+      it('should include metric in z-score title for ASMR', () => {
+        const result = callGetChartLabels({ type: 'asmr', view: 'zscore' })
+
+        const title = result.title.join(' ')
+        expect(title).toContain('Z-Score')
+        expect(title).toContain('Age-Standardized')
+      })
+
+      it('should include metric in z-score title for CMR with age group', () => {
+        const result = callGetChartLabels({
+          type: 'cmr',
+          view: 'zscore',
+          ageGroups: ['65-74']
+        })
+
+        const title = result.title.join(' ')
+        expect(title).toContain('Z-Score')
+        expect(title).toContain('Mortality Rate')
+        expect(title).toContain('[65-74]')
+      })
     })
 
     describe('subtitle generation', () => {


### PR DESCRIPTION
## Summary
- Z-score view's title was hard-coded to "Z-Score Analysis"; exports/screenshots were ambiguous about whether the chart showed LE, ASMR, CMR, deaths, etc.
- Title now includes the metric name, matching the title pattern used by the mortality and excess views.

Examples after this change:
- `Z-Score Life Expectancy`
- `Z-Score Age-Standardized Mortality Rate`
- `Z-Score Crude Mortality Rate [65-74]`

## Test plan
- [x] `bun vitest run app/lib/chart/labels.test.ts` — all 58 tests pass (3 new z-score title tests)
- [x] `bun vitest run` — full suite green
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)