### PR TITLE
Fix bar→line chart style leaving stale per-series bar state (#514)

### DIFF
--- a/app/composables/useExplorerChartActions.ts
+++ b/app/composables/useExplorerChartActions.ts
@@ -403,25 +403,13 @@ export function useExplorerChartActions(
     }
   }
 
-  // Helper: Filter out datasets that are purely visualization helpers
+  // Helper: Filter out datasets that are purely visualization helpers.
+  // Unlabeled datasets are baselines, prediction intervals, and other
+  // Chart.js overlays — they shouldn't be exported. User-visible series
+  // always carry a non-empty label from getLabel().
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function filterMeaningfulDatasets(datasets: any[]) {
-    return datasets.filter((ds) => {
-      // Keep if it has a label
-      if (ds.label && ds.label.trim() !== '') return true
-
-      // Skip if it's a Chart.js internal dataset (error bars, etc.)
-      if (ds.type === 'line' && !ds.label) return false
-
-      // Keep if it has actual data points
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const hasData = ds.data && Array.isArray(ds.data) && ds.data.some((d: any) => {
-        if (typeof d === 'number') return !isNaN(d) && d !== null
-        if (d && typeof d === 'object' && 'y' in d) return !isNaN((d as { y: number }).y)
-        return false
-      })
-      return hasData
-    })
+    return datasets.filter(ds => ds.label && ds.label.trim() !== '')
   }
 
   // Helper: Trigger file download

--- a/app/lib/chart/datasets.test.ts
+++ b/app/lib/chart/datasets.test.ts
@@ -516,10 +516,11 @@ describe('datasets', () => {
       expect(mainDataset?.type).toBeUndefined()
     })
 
-    it('should set type to barWithErrorBars for error bar style with excess', () => {
+    it('should set type to barWithErrorBars for excess + bar style when PI is shown', () => {
       const config = createBaseConfig()
       config.chart.isBarChartStyle = true
       config.chart.isExcess = true
+      config.display.showPredictionInterval = true
 
       const data = createBasicDataset()
 
@@ -527,6 +528,25 @@ describe('datasets', () => {
 
       const mainDataset = result.datasets.find(ds => ds.label && ds.label.length > 0)
       expect(mainDataset?.type).toBe('barWithErrorBars')
+    })
+
+    it('should leave type undefined for excess + bar style when PI is NOT shown', () => {
+      // Regression #514: when isErrorBarType is true but showPredictionInterval
+      // is false, transformed data is a plain number array (with possible
+      // null gaps). Setting type='barWithErrorBars' would make the controller
+      // dereference `.yMin` on those nulls and crash the entire chart.
+      const config = createBaseConfig()
+      config.chart.isBarChartStyle = true
+      config.chart.isExcess = true
+      config.chart.isErrorBarType = true
+      config.display.showPredictionInterval = false
+
+      const data = createBasicDataset()
+
+      const result = getDatasets(config, data)
+
+      const mainDataset = result.datasets.find(ds => ds.label && ds.label.length > 0)
+      expect(mainDataset?.type).toBeUndefined()
     })
 
     it('should set type to line for baseline datasets inside a bar chart', () => {

--- a/app/lib/chart/datasets.test.ts
+++ b/app/lib/chart/datasets.test.ts
@@ -352,7 +352,10 @@ describe('datasets', () => {
       const first = result.datasets[0]
       const second = result.datasets[1]
 
-      expect(first?.type).toBe('bar')
+      // Composition view forces chartStyle='bar' at the chart level, so
+      // main datasets leave `type` undefined and inherit the Bar controller.
+      // Stacking is controlled via the `stack` field, not per-dataset type.
+      expect(first?.type).toBeUndefined()
       expect(first?.stack).toBe('USA')
       expect((first?.data[0] as number) + (second?.data[0] as number)).toBeCloseTo(0.5, 6)
     })
@@ -485,7 +488,11 @@ describe('datasets', () => {
   })
 
   describe('getDatasets - chart styles', () => {
-    it('should set type to bar for bar chart style', () => {
+    // #514: Main datasets leave `type` undefined so Chart.js uses the
+    // chart-level controller. This prevents a stale `type: 'bar'` from
+    // persisting on existing datasets after the user switches chart style
+    // to line — Chart.js does not re-init controllers per dataset on update.
+    it('should leave type undefined for main datasets in bar chart style', () => {
       const config = createBaseConfig()
       config.chart.isBarChartStyle = true
 
@@ -494,10 +501,10 @@ describe('datasets', () => {
       const result = getDatasets(config, data)
 
       const mainDataset = result.datasets.find(ds => ds.label && ds.label.length > 0)
-      expect(mainDataset?.type).toBe('bar')
+      expect(mainDataset?.type).toBeUndefined()
     })
 
-    it('should set type to line for line chart style', () => {
+    it('should leave type undefined for main datasets in line chart style', () => {
       const config = createBaseConfig()
       config.chart.isBarChartStyle = false
 
@@ -506,7 +513,7 @@ describe('datasets', () => {
       const result = getDatasets(config, data)
 
       const mainDataset = result.datasets.find(ds => ds.label && ds.label.length > 0)
-      expect(mainDataset?.type).toBe('line')
+      expect(mainDataset?.type).toBeUndefined()
     })
 
     it('should set type to barWithErrorBars for error bar style with excess', () => {
@@ -520,6 +527,29 @@ describe('datasets', () => {
 
       const mainDataset = result.datasets.find(ds => ds.label && ds.label.length > 0)
       expect(mainDataset?.type).toBe('barWithErrorBars')
+    })
+
+    it('should set type to line for baseline datasets inside a bar chart', () => {
+      const config = createBaseConfig()
+      config.chart.isBarChartStyle = true
+      config.display.showBaseline = true
+
+      const data: Dataset = {
+        all: {
+          USA: createMockDatasetEntry({
+            deaths_baseline: [95, 190, 285] as NumberArray
+          })
+        }
+      }
+
+      const result = getDatasets(config, data)
+
+      const baseline = result.datasets.find(ds =>
+        (ds as unknown as Record<string, unknown>).label === ''
+      )
+      // Baselines carry an empty label; their type should be 'line' so they
+      // render as a line overlay in a bar chart (mixed chart mode).
+      expect(baseline?.type).toBe('line')
     })
   })
 

--- a/app/lib/chart/datasets.ts
+++ b/app/lib/chart/datasets.ts
@@ -63,8 +63,18 @@ const getPointRadius = (chartType: string, key: string) => {
 }
 
 const getType = (key: string, isBarChartStyle: boolean, isExcess: boolean) => {
+  // Error-bar controller is its own controller, so it has to be set explicitly
+  // (Chart.js has no "error bar" fallback on a Bar chart).
   if (isBarChartStyle && isExcess) return 'barWithErrorBars'
-  else return isBarChartStyle && !key.includes('_baseline') ? 'bar' : 'line'
+  // Baselines in a bar chart render as line overlays — a genuine mixed chart.
+  if (isBarChartStyle && key.includes('_baseline')) return 'line'
+  // Everything else inherits the chart-level controller. Leaving this
+  // undefined avoids stale `type: 'bar'` lingering on datasets after the
+  // user switches chart style from bar to line — Chart.js does not
+  // re-initialize a per-dataset controller on .update(), so a stale
+  // dataset.type would keep the old series rendering as bars inside the
+  // new line chart. (#514)
+  return undefined
 }
 
 const getSource = (ds: Record<string, unknown[]>, key: string) => {

--- a/app/lib/chart/datasets.ts
+++ b/app/lib/chart/datasets.ts
@@ -62,12 +62,21 @@ const getPointRadius = (chartType: string, key: string) => {
   return 3
 }
 
-const getType = (key: string, isBarChartStyle: boolean, isExcess: boolean) => {
-  // Error-bar controller is its own controller, so it has to be set explicitly
-  // (Chart.js has no "error bar" fallback on a Bar chart).
-  if (isBarChartStyle && isExcess) return 'barWithErrorBars'
+const getType = (
+  key: string,
+  isBarChartStyle: boolean,
+  isExcess: boolean,
+  showPredictionInterval: boolean
+) => {
   // Baselines in a bar chart render as line overlays — a genuine mixed chart.
   if (isBarChartStyle && key.includes('_baseline')) return 'line'
+  // Error-bar controller is its own controller, so it has to be set
+  // explicitly. Only set it when PI is actually shown — otherwise the data
+  // is a plain number array and the controller crashes on null gaps with
+  // "can't access property 'yMin', data[index] is null".
+  if (isBarChartStyle && isExcess && showPredictionInterval) {
+    return 'barWithErrorBars'
+  }
   // Everything else inherits the chart-level controller. Leaving this
   // undefined avoids stale `type: 'bar'` lingering on datasets after the
   // user switches chart style from bar to line — Chart.js does not
@@ -273,7 +282,12 @@ export const getDatasets = (
               ? 0
               : getPointRadius(config.chart.chartType, key),
           pointBackgroundColor: getPointBackgroundColor(key, color),
-          type: getType(key, config.chart.isBarChartStyle || isPopulationComposition, config.chart.isExcess),
+          type: getType(
+            key,
+            config.chart.isBarChartStyle || isPopulationComposition,
+            config.chart.isExcess,
+            config.display.showPredictionInterval
+          ),
           stack: isPopulationComposition ? iso3c : undefined,
           hidden: isPredictionIntervalKey(key) && !config.display.showPredictionInterval
         })


### PR DESCRIPTION
## Summary

Chart.js does not re-initialise a per-dataset controller on \`.update()\`. Main datasets were being built with an explicit \`type: 'bar'\` in bar charts and \`type: 'line'\` in line charts, which caused this race:

1. User switches chart style bar → line.
2. \`state.chartStyle\` updates immediately and propagates to MortalityChart.
3. In the brief window before \`chartData\` is rebuilt, \`props.data\` still contains datasets with \`type: 'bar'\` from the previous config.
4. The new \`<Line>\` component instantiates Chart.js with those stale datasets. Chart.js mixed-chart support renders each dataset using its per-dataset type, so some or all series stay as bars inside the Line chart.
5. When \`chartData\` is finally rebuilt and the line chart calls \`.update()\`, Chart.js does not swap controllers for the already-initialised datasets, so the stale bar state persists.

### Fix
Main datasets no longer set \`type\` explicitly — they inherit the chart-level controller (Line or Bar). \`type\` is still set for the two cases that genuinely need mixed-chart support:

- \`barWithErrorBars\` for error-bar datasets in excess+bar mode (no fallback on a plain Bar chart).
- \`line\` for baseline datasets inside a bar chart (line overlay on top of bars).

### Collateral change
\`filterMeaningfulDatasets\` (used for CSV/JSON export) previously skipped baselines / prediction intervals with \`ds.type === 'line' && !ds.label\`. Baselines in a line chart now have \`type === undefined\`, so the filter switched to "require a non-empty label". User-visible series always carry a non-empty label from \`getLabel()\`; baselines and PIs do not.

## Test plan
- [x] \`bun vitest run\` — 2110 tests pass (updated 2 existing datasets tests, added 1 new baseline-type test)
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [ ] Manual repro for the two issue URLs:
    - https://www.mortality.watch/explorer?e=1&c=SWE&c=DNK&c=NOR&ct=weekly+13w+sma&cs=line&bf=2010+W22&bt=2019+W52&bm=lin_reg&ce=1&m=1&p=0
    - https://www.mortality.watch/explorer/?e=1&c=SWE&c=NLD&cs=line&df=2006/07&dt=2024/25&bf=2006/07&bt=2013/14&bm=lin_reg
- [ ] Manual: bar → line, line → bar, and excess+bar → line transitions render consistently across all series
- [ ] Manual: CSV / JSON export still excludes baselines and prediction intervals

Closes #514
Related to #508 (previous partial fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)