### PR TITLE
Remove paid/Pro listings from admin panel

### DIFF
--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -15,7 +15,6 @@ const config = useRuntimeConfig()
 const { data: statsData } = await useFetch<{
   totalUsers: number
   signupsThisWeek: number
-  proSubscribers: number
   savedCharts: number
 }>('/api/admin/stats')
 
@@ -31,12 +30,6 @@ const stats = computed(() => [
     value: String(statsData.value?.signupsThisWeek || 0),
     icon: 'i-lucide-user-plus',
     color: 'success' as const
-  },
-  {
-    label: 'Paying Subscribers',
-    value: String(statsData.value?.proSubscribers || 0),
-    icon: 'i-lucide-crown',
-    color: 'warning' as const
   },
   {
     label: 'Saved Charts',
@@ -85,7 +78,7 @@ const quickActions = [
     </div>
 
     <!-- Stats Grid -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
       <UCard
         v-for="stat in stats"
         :key="stat.label"

--- a/app/pages/admin/invite-codes.vue
+++ b/app/pages/admin/invite-codes.vue
@@ -15,7 +15,6 @@ interface InviteCode {
   maxUses: number
   currentUses: number
   expiresAt: Date | null
-  grantsProUntil: Date | null
   notes: string | null
   isActive: boolean
   createdAt: Date
@@ -35,7 +34,6 @@ const newCode = ref({
   code: '',
   maxUses: 1,
   expiresAt: '',
-  grantsProMonths: 6,
   notes: ''
 })
 
@@ -88,8 +86,7 @@ async function createInviteCode() {
       method: 'POST',
       body: {
         code: newCode.value.code.trim().toUpperCase(),
-        maxUses: newCode.value.maxUses,
-        grantsProMonths: newCode.value.grantsProMonths
+        maxUses: newCode.value.maxUses
       }
     })
 
@@ -105,7 +102,6 @@ async function createInviteCode() {
       code: '',
       maxUses: 1,
       expiresAt: '',
-      grantsProMonths: 6,
       notes: ''
     }
     showCreateModal.value = false
@@ -225,12 +221,6 @@ async function copyCode(code: string) {
   }
 }
 
-// Format date
-function formatDate(date: Date | null) {
-  if (!date) return 'Never'
-  return new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-}
-
 // Compute code status
 function getCodeStatus(code: InviteCode) {
   if (!code.isActive) return 'Inactive'
@@ -322,9 +312,6 @@ onMounted(() => {
               <div>
                 <span class="font-medium">Uses:</span> {{ code.currentUses }} / {{ code.maxUses }}
               </div>
-              <div>
-                <span class="font-medium">Pro Until:</span> {{ formatDate(code.grantsProUntil) }}
-              </div>
             </div>
           </div>
 
@@ -398,18 +385,6 @@ onMounted(() => {
               v-model.number="newCode.maxUses"
               type="number"
               min="1"
-            />
-          </UFormField>
-
-          <UFormField
-            label="Pro Access Duration"
-            help="How long users get Pro access (in months)"
-          >
-            <UInput
-              v-model.number="newCode.grantsProMonths"
-              type="number"
-              min="1"
-              max="24"
             />
           </UFormField>
         </div>

--- a/server/api/admin/stats.get.ts
+++ b/server/api/admin/stats.get.ts
@@ -1,6 +1,6 @@
 import { sql, gte } from 'drizzle-orm'
 import { db } from '../../utils/db'
-import { users, savedCharts, subscriptions } from '../../../db/schema'
+import { users, savedCharts } from '../../../db/schema'
 import { requireAdmin } from '../../utils/auth'
 
 /**
@@ -20,37 +20,24 @@ export default defineEventHandler(async (event) => {
   weekStart.setHours(0, 0, 0, 0)
 
   // Run all queries in parallel for efficiency
-  const [
-    totalUsersResult,
-    signupsThisWeekResult,
-    proSubscribersResult,
-    savedChartsResult
-  ] = await Promise.all([
-    // Total users
-    db.select({ count: sql<number>`count(*)` }).from(users),
+  const [totalUsersResult, signupsThisWeekResult, savedChartsResult]
+    = await Promise.all([
+      // Total users
+      db.select({ count: sql<number>`count(*)` }).from(users),
 
-    // Signups this week (since Monday)
-    db
-      .select({ count: sql<number>`count(*)` })
-      .from(users)
-      .where(gte(users.createdAt, weekStart)),
+      // Signups this week (since Monday)
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(users)
+        .where(gte(users.createdAt, weekStart)),
 
-    // Paying subscribers (active Stripe subscription only)
-    db
-      .select({ count: sql<number>`count(*)` })
-      .from(subscriptions)
-      .where(
-        sql`${subscriptions.status} = 'active' AND ${subscriptions.stripeSubscriptionId} IS NOT NULL`
-      ),
-
-    // Saved charts count
-    db.select({ count: sql<number>`count(*)` }).from(savedCharts)
-  ])
+      // Saved charts count
+      db.select({ count: sql<number>`count(*)` }).from(savedCharts)
+    ])
 
   return {
     totalUsers: totalUsersResult[0]?.count || 0,
     signupsThisWeek: signupsThisWeekResult[0]?.count || 0,
-    proSubscribers: proSubscribersResult[0]?.count || 0,
     savedCharts: savedChartsResult[0]?.count || 0
   }
 })


### PR DESCRIPTION
## Summary
After #520 disabled payments and auto-granted Pro on registration, the admin panel still surfaces stale paid-tier concepts:

- \`/admin\` dashboard shows a **Paying Subscribers** card (always zero in the two-tier model; the query also hits the now-inert \`subscriptions\` table).
- \`/admin/invite-codes\` still displays a **Pro Until** column and exposes a **Pro Access Duration** field on the create form. With registration alone granting Pro, per-code duration has no effect — the UI is clutter.

### Changes
- \`/admin\`: drop the Paying Subscribers stat and widen the stats grid from 4 → 3 columns.
- \`/api/admin/stats\`: remove the \`proSubscribers\` subscriptions query and the corresponding response field.
- \`/admin/invite-codes\`: remove the Pro Until row, the Pro Access Duration form field, and stop sending \`grantsProMonths\` on create.
- Server schema keeps \`grantsProMonths\` optional, so any existing codes with \`grantsProUntil\` set keep working.

## Test plan
- [x] \`bun run lint\` — clean
- [x] \`bun vitest run\` — 2103 tests pass
- [ ] Manual: /admin renders 3 stats (no Paying Subscribers), /admin/invite-codes create flow has no Pro Access Duration field, listing has no Pro Until row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)