### PR TITLE
chore: disable nuxt-og-image dynamic runtime

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -128,6 +128,10 @@ export default defineNuxtConfig({
     }
   },
 
+  ogImage: {
+    zeroRuntime: true
+  },
+
   // Umami Analytics configuration
   umami: {
     id: process.env.NUXT_UMAMI_ID || '',


### PR DESCRIPTION
## Summary
- Sets `ogImage: { zeroRuntime: true }` in `nuxt.config.ts` to silence the unsigned-OG-URL warning and disable dynamic image generation entirely.

## Why
On boot, `@nuxtjs/og-image` warns:

> OG image URLs are not signed. Anyone can craft arbitrary image generation requests.

We don't need on-demand image generation, so the simplest fix is zero-runtime mode (alternative was setting `NUXT_OG_IMAGE_SECRET`).

## Test plan
- [ ] Verify the warning no longer appears at dev server startup
- [ ] Confirm any pre-rendered OG images (if used) still render correctly