### PR TITLE
chore: collapse Pro tier into Registered now that payments are off

### DIFF
--- a/app/components/FeatureBadge.vue
+++ b/app/components/FeatureBadge.vue
@@ -58,7 +58,7 @@ const badgeClasses = computed(() => {
     case TIERS.REGISTERED:
       return `${baseClasses} bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400`
     case TIERS.PRO:
-      return `${baseClasses} bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400`
+      return `${baseClasses} bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400`
     default:
       return `${baseClasses} bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300`
   }
@@ -73,7 +73,7 @@ const tierName = computed(() => {
     case TIERS.REGISTERED:
       return 'Sign Up'
     case TIERS.PRO:
-      return 'Upgrade'
+      return 'Sign Up'
     default:
       return 'Unknown'
   }

--- a/app/components/FeatureBadge.vue
+++ b/app/components/FeatureBadge.vue
@@ -57,8 +57,6 @@ const badgeClasses = computed(() => {
       return `${baseClasses} bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300`
     case TIERS.REGISTERED:
       return `${baseClasses} bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400`
-    case TIERS.PRO:
-      return `${baseClasses} bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400`
     default:
       return `${baseClasses} bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300`
   }
@@ -71,8 +69,6 @@ const tierName = computed(() => {
     case TIERS.PUBLIC:
       return 'Public'
     case TIERS.REGISTERED:
-      return 'Sign Up'
-    case TIERS.PRO:
       return 'Sign Up'
     default:
       return 'Unknown'

--- a/app/components/TierBadge.vue
+++ b/app/components/TierBadge.vue
@@ -21,18 +21,19 @@ const badgeClasses = computed(() => {
     lg: 'px-3 py-1 text-sm'
   }
 
-  // Tier-specific color classes
+  // Tier-specific color classes (tier 2 is treated the same as tier 1
+  // since payments were disabled and Pro collapsed into Registered)
   const colorClasses = {
-    2: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400', // Pro
-    1: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400', // Free
-    0: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300' // Public
+    2: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    1: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    0: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
   }
 
   return `${baseClasses} ${sizeClasses[props.size]} ${colorClasses[props.tier]}`
 })
 
 const tierLabels: Record<number, string> = {
-  2: 'Pro',
+  2: 'Free',
   1: 'Free',
   0: 'Public'
 }

--- a/app/components/charts/controls/DataTab.vue
+++ b/app/components/charts/controls/DataTab.vue
@@ -30,14 +30,14 @@ const emit = defineEmits<{
   'update:view': [value: ViewType]
 }>()
 
-// Gate ASD metric for Pro users
+// Gate ASD metric — requires a registered account
 const hasASDAccess = can('AGE_STANDARDIZED')
 
 // Add 'label' property for USelect compatibility
-// Also mark ASD as disabled if user doesn't have Pro access
+// Mark ASD as disabled and surface the gate when the user is anonymous
 const typesWithLabels = computed(() => types.map(t => ({
   ...t,
-  label: t.value === 'asd' && !hasASDAccess ? `${t.name} (Pro)` : t.name,
+  label: t.value === 'asd' && !hasASDAccess ? `${t.name} (Sign up)` : t.name,
   disabled: t.value === 'asd' && !hasASDAccess
 })))
 const standardPopulationsWithLabels = standardPopulations.map(t => ({ ...t, label: t.name }))

--- a/app/components/discover/MetricPresetsGrid.vue
+++ b/app/components/discover/MetricPresetsGrid.vue
@@ -49,20 +49,18 @@ const props = defineProps<Props>()
 const colorMode = useColorMode()
 const { can, getFeatureUpgradeUrl } = useFeatureAccess()
 
-// Check if a view is a Pro feature
-function isProFeature(view: View): boolean {
+// Check if a view requires a registered account
+function isGatedFeature(view: View): boolean {
   return view === 'zscore'
 }
 
-// Get the feature key for a Pro feature (only called for pro views)
 function getFeatureKey(): FeatureKey {
-  // zscore is the only pro feature view
   return 'Z_SCORES'
 }
 
 // Check if view is locked for current user
 function isLocked(view: View): boolean {
-  return isProFeature(view) && !can(getFeatureKey())
+  return isGatedFeature(view) && !can(getFeatureKey())
 }
 
 // Get available views for a metric (Population only has 'normal')

--- a/app/components/discover/PresetsMatrix.vue
+++ b/app/components/discover/PresetsMatrix.vue
@@ -258,19 +258,18 @@ const gridColsClass = computed(() => {
   }
 })
 
-// Check if a view is a Pro feature
-function isProFeature(view: View): boolean {
+// Check if a view requires a registered account
+function isGatedFeature(view: View): boolean {
   return view === 'zscore'
 }
 
-// Get the feature key for a Pro feature
 function getFeatureKey() {
   return 'Z_SCORES' as const
 }
 
 // Check if view is locked for current user
 function isLocked(view: View): boolean {
-  return isProFeature(view) && !can(getFeatureKey())
+  return isGatedFeature(view) && !can(getFeatureKey())
 }
 
 // Get the view to show for a metric

--- a/app/config/features.config.ts
+++ b/app/config/features.config.ts
@@ -32,10 +32,13 @@ export const TIER_INFO = {
     price: 'Free',
     signupRequired: true
   },
+  // Retained as an alias for backward compatibility with the Stripe webhook
+  // and admin scripts that still reference the constant. No live feature is
+  // gated to this tier — all formerly Pro features now require REGISTERED.
   [TIERS.PRO]: {
-    name: 'Pro',
-    description: 'Premium subscription with advanced features',
-    price: '$9.99/month',
+    name: 'Free',
+    description: 'Free account with extended features',
+    price: 'Free',
     signupRequired: true
   }
 } as const
@@ -136,116 +139,117 @@ export const FEATURES = {
   },
 
   // ==========================================
-  // TIER 2 (PRO - PAID) - Advanced features
+  // Formerly TIER 2 (PRO - PAID) - now bundled
+  // into REGISTERED since payments were disabled
   // ==========================================
 
   CUSTOM_CHART_SIZE: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Custom Chart Size',
     description: 'Customize chart dimensions and aspect ratios',
     category: 'customization'
   },
 
   CUSTOM_DECIMALS: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Custom Number Precision',
     description: 'Control decimal places in chart values',
     category: 'customization'
   },
 
   HIDE_WATERMARK: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Hide Watermark',
     description: 'Remove site watermark from charts',
     category: 'branding'
   },
 
   HIDE_QR: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Hide QR Code',
     description: 'Remove QR code from charts',
     category: 'branding'
   },
 
   SHOW_CAPTION: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Show Caption',
     description: 'Display chart caption with metadata',
     category: 'branding'
   },
 
   HIDE_TITLE: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Hide Title',
     description: 'Hide chart title',
     category: 'branding'
   },
 
   HIDE_LEGEND: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Hide Legend',
     description: 'Hide chart legend',
     category: 'branding'
   },
 
   HIDE_X_AXIS_TITLE: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Hide X-Axis Title',
     description: 'Hide x-axis title label',
     category: 'branding'
   },
 
   HIDE_Y_AXIS_TITLE: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Hide Y-Axis Title',
     description: 'Hide y-axis title label',
     category: 'branding'
   },
 
   ADVANCED_LE: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Advanced Life Expectancy',
     description: 'Single age group LE calculations',
     category: 'analysis'
   },
 
   Z_SCORES: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Z-Scores',
     description: 'Statistical z-score calculations',
     category: 'analysis'
   },
 
   SORT_BY_VALUE: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Sort by Value',
     description: 'Reorder chart series by latest data value',
     category: 'analysis'
   },
 
   AGE_STANDARDIZED: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Age Standardized Deaths',
     description: 'Age-standardized death rates (Levitt method)',
     category: 'analysis'
   },
 
   BROWSE_ALL_CHARTS: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Global Chart History',
     description: 'Browse all chart variants ever created on the platform',
     category: 'core'
   },
 
   PRIORITY_SUPPORT: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'Priority Support',
     description: 'Priority customer support',
     category: 'support'
   },
 
   API_ACCESS: {
-    tier: TIERS.PRO,
+    tier: TIERS.REGISTERED,
     name: 'API Access',
     description: 'REST API access (coming soon)',
     category: 'api'

--- a/app/lib/featureFlags.ts
+++ b/app/lib/featureFlags.ts
@@ -55,13 +55,8 @@ export function getUpgradeMessage(
     return ''
   }
 
-  // Need to register (Tier 1)
+  // Need to register
   if (requiredTier === TIERS.REGISTERED) {
-    return 'Sign up for a free account to unlock this feature'
-  }
-
-  // Pro-gated features are now unlocked by registration
-  if (requiredTier === TIERS.PRO) {
     return 'Sign up for a free account to unlock this feature'
   }
 
@@ -79,10 +74,6 @@ export function getUpgradeUrl(
     const requiredTier = FEATURES[feature].tier
 
     if (requiredTier === TIERS.REGISTERED && userTier === TIERS.PUBLIC) {
-      return '/signup'
-    }
-
-    if (requiredTier === TIERS.PRO) {
       return '/signup'
     }
   }
@@ -106,10 +97,6 @@ export function getUpgradeCTA(
     const requiredTier = FEATURES[feature].tier
 
     if (requiredTier === TIERS.REGISTERED && userTier === TIERS.PUBLIC) {
-      return 'Sign Up Free'
-    }
-
-    if (requiredTier === TIERS.PRO) {
       return 'Sign Up Free'
     }
   }

--- a/app/pages/discover/metric/index.vue
+++ b/app/pages/discover/metric/index.vue
@@ -39,7 +39,7 @@
         v-for="metric in metrics"
         :key="metric"
       >
-        <!-- Pro-gated metric (ASD) -->
+        <!-- Registration-gated metric (ASD) -->
         <NuxtLink
           v-if="isProMetric(metric)"
           :to="can('AGE_STANDARDIZED') ? `/discover/metric/${metric}` : getFeatureUpgradeUrl('AGE_STANDARDIZED')"
@@ -159,7 +159,7 @@ import { metricInfo } from '@/lib/discover/constants'
 
 const { can, getFeatureUpgradeUrl } = useFeatureAccess()
 
-// Check if metric is Pro-gated
+// Check if metric requires a registered account (ASD = AGE_STANDARDIZED)
 function isProMetric(metric: Metric): boolean {
   return metric === 'asd'
 }


### PR DESCRIPTION
## Summary

Since #520 disabled payments and every authenticated user is auto-granted tier 2, the "Pro" labels in the metric dropdown, tier badge, and discover/feature badges no longer reflect any real access boundary — just leftover UI debt.

This PR consolidates everything under the **Registered** gate so the UX matches the actual two-tier (Public / Registered) model. `TIERS.PRO` is kept as a back-compat alias for the Stripe webhook and admin scripts, but no live feature is gated to it.

## Changes
- `features.config.ts`: every formerly-Pro feature now requires `REGISTERED`. `TIER_INFO[PRO]` maps to "Free".
- `DataTab.vue`: ASD metric suffix `(Pro)` → `(Sign up)` so the gate text matches the actual remediation.
- `TierBadge.vue`: drop the purple "Pro" pill — tier 2 renders as "Free" in blue.
- `FeatureBadge.vue`: PRO branch returns "Sign Up" (was "Upgrade").
- `discover/PresetsMatrix.vue`, `discover/MetricPresetsGrid.vue`: rename `isProFeature` → `isGatedFeature`.
- `discover/metric/index.vue`: update gating comment for the ASD card.

Defensive `TIERS.PRO` branches in `featureFlags.ts` are left in place — dead but harmless, and removing them would silently change behavior if any third-party code still passes PRO.

## Test plan
- [x] `npx vitest run` — 2105 / 2105 passing
- [x] `npm run lint` — clean
- [ ] Open `/explorer` as anonymous user → ASD shows "(Sign up)", not "(Pro)"
- [ ] Sign in → tier badge shows "Free", not "Pro"
- [ ] Open `/discover` → z-score and ASD remain locked for anonymous, accessible after sign-up