### PR TITLE
Fix LE age group reset for logged-out users

### DIFF
--- a/app/components/charts/MortalityChartControlsPrimary.vue
+++ b/app/components/charts/MortalityChartControlsPrimary.vue
@@ -3,9 +3,9 @@ import type { Country } from '@/model'
 import { computed, toRaw } from 'vue'
 import { showToast } from '../../toast'
 
-// Feature access for LE single age groups (Pro feature)
+// Feature access for LE single age groups (registered users only)
 const { can } = useFeatureAccess()
-const canAdvancedLE = can('ADVANCED_LE')
+const canAdvancedLE = computed(() => can('ADVANCED_LE'))
 
 const props = defineProps<{
   allCountries: Record<string, Country>

--- a/app/lib/state/normalizeLeAgeGroups.test.ts
+++ b/app/lib/state/normalizeLeAgeGroups.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { shouldNormalizeLeAgeGroups } from './normalizeLeAgeGroups'
+
+describe('shouldNormalizeLeAgeGroups', () => {
+  it('does not normalize non-LE metrics', () => {
+    expect(shouldNormalizeLeAgeGroups('cmr', false, ['40-49', '50-59'])).toBe(false)
+  })
+
+  it('does not normalize LE when ADVANCED_LE is available', () => {
+    expect(shouldNormalizeLeAgeGroups('le', true, ['40-49', '50-59'])).toBe(false)
+  })
+
+  it('does not normalize all-ages LE for users without ADVANCED_LE', () => {
+    expect(shouldNormalizeLeAgeGroups('le', false, ['all'])).toBe(false)
+  })
+
+  it('normalizes single-age-group LE for users without ADVANCED_LE', () => {
+    expect(shouldNormalizeLeAgeGroups('le', false, ['50-59'])).toBe(true)
+  })
+
+  it('normalizes multi-age-group LE for users without ADVANCED_LE', () => {
+    expect(shouldNormalizeLeAgeGroups('le', false, ['40-49', '50-59'])).toBe(true)
+  })
+
+  it('normalizes empty LE age-group selection for users without ADVANCED_LE', () => {
+    expect(shouldNormalizeLeAgeGroups('le', false, [])).toBe(true)
+  })
+})

--- a/app/lib/state/normalizeLeAgeGroups.ts
+++ b/app/lib/state/normalizeLeAgeGroups.ts
@@ -1,0 +1,19 @@
+/**
+ * Life expectancy age-group normalization for users without ADVANCED_LE access.
+ *
+ * Logged-out users can arrive on LE charts carrying age-group selections from
+ * other metrics (for example via URL params or metric switching). Because the
+ * LE age-group control is hidden for them, we must normalize back to all-ages
+ * LE to avoid leaving the UI in a hidden invalid state.
+ */
+
+export function shouldNormalizeLeAgeGroups(
+  type: string,
+  hasAdvancedLEAccess: boolean,
+  ageGroups: string[]
+): boolean {
+  if (type !== 'le') return false
+  if (hasAdvancedLEAccess) return false
+  if (ageGroups.length !== 1) return true
+  return ageGroups[0] !== 'all'
+}

--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -33,6 +33,7 @@ import ChartActions from '@/components/charts/ChartActions.vue'
 import SaveModal from '@/components/SaveModal.vue'
 import { generateExplorerTitle, generateExplorerDescription } from '@/lib/utils/chartTitles'
 import { computeConfigHash, extractUrlParams } from '@/lib/shortUrl/hashConfig'
+import { shouldNormalizeLeAgeGroups } from '@/lib/state/normalizeLeAgeGroups'
 import { selectMutuallyExclusiveAgeGroups } from '@/services/metadataService'
 import { decodeChartState, type ChartState } from '@/lib/chartState'
 
@@ -41,7 +42,8 @@ const { isAuthenticated } = useAuth()
 const { goToSignup } = useAuthRedirect()
 
 // Feature access for tier-gated features
-const { isPro } = useFeatureAccess()
+const { isPro, can } = useFeatureAccess()
+const canAdvancedLE = computed(() => can('ADVANCED_LE'))
 
 // Tutorial for first-time users
 const { autoStartTutorial } = useTutorial()
@@ -427,6 +429,13 @@ const handleChartStyleChanged = (v: string) => handleStateChange({ field: 'chart
 const handleCountriesChanged = (v: string[]) => handleStateChange({ field: 'countries', value: v }, '_countries')
 const handleAgeGroupsChanged = (v: string[]) => handleStateChange({ field: 'ageGroups', value: v }, '_ageGroups')
 const handleStandardPopulationChanged = (v: string) => handleStateChange({ field: 'standardPopulation', value: v }, '_standardPopulation')
+
+// Logged-out users cannot edit LE age groups, so normalize stale selections
+// from URLs or metric switching back to all-ages LE.
+watch([() => state.type.value, () => state.ageGroups.value, canAdvancedLE], async ([type, ageGroups, hasAdvancedLEAccess]) => {
+  if (!shouldNormalizeLeAgeGroups(type, hasAdvancedLEAccess, ageGroups || [])) return
+  await handleStateChange({ field: 'ageGroups', value: ['all'] }, '_ageGroups')
+}, { immediate: true })
 
 // Composition view defaults to all individual age bands (exclude aggregate "all")
 watch([() => state.view.value, allAgeGroups], async ([viewType, availableAgeGroups]) => {


### PR DESCRIPTION
Summary:
- reset LE age groups to all for users without ADVANCED_LE so stale ag params do not leave the explorer in a hidden invalid state
- make the ADVANCED_LE gate reactive in the primary chart controls
- add a regression test for the LE age-group normalization rule

Root cause:
Switching from CMR to LE could carry over age groups like 40-49 and 50-59 in state and URL. Logged-out users cannot edit LE age groups because the LE picker is hidden behind ADVANCED_LE, so they could end up with a blank chart and no visible way to recover.

Test plan:
- npm test -- app/lib/state/normalizeLeAgeGroups.test.ts
- npm run typecheck
- npm run lint -- app/pages/explorer.vue app/components/charts/MortalityChartControlsPrimary.vue app/lib/state/normalizeLeAgeGroups.ts app/lib/state/normalizeLeAgeGroups.test.ts (fails in this environment before linting project files because the local Node runtime lacks Object.groupBy, which ESLint config now expects)