### PR TITLE
Fix explorer view reset and LE chart-type normalization

### DIFF
--- a/app/lib/state/config/constraints.test.ts
+++ b/app/lib/state/config/constraints.test.ts
@@ -151,6 +151,35 @@ describe('StateResolver Constraints', () => {
       // not enforced by constraints
       expect(constraint).toBeUndefined()
     })
+
+    it('should force yearly chart type for age-specific LE on sub-yearly charts', () => {
+      const state = {
+        type: 'le',
+        chartType: 'weekly',
+        ageGroups: ['40-49', '50-59']
+      }
+      const constraint = STATE_CONSTRAINTS.find(
+        c => c.when(state) && c.apply.chartType === 'yearly'
+      )
+
+      expect(constraint).toBeDefined()
+      expect(constraint?.reason).toContain('Age-specific life expectancy')
+      expect(constraint?.allowUserOverride).toBe(false)
+      expect(constraint?.priority).toBe(2)
+    })
+
+    it('should preserve sub-yearly chart type for all-ages LE', () => {
+      const state = {
+        type: 'le',
+        chartType: 'weekly',
+        ageGroups: ['all']
+      }
+      const constraint = STATE_CONSTRAINTS.find(
+        c => c.when(state) && c.apply.chartType === 'yearly'
+      )
+
+      expect(constraint).toBeUndefined()
+    })
   })
 
   describe('Matrix Chart Style Constraints', () => {

--- a/app/lib/state/config/constraints.ts
+++ b/app/lib/state/config/constraints.ts
@@ -218,6 +218,27 @@ const asdChartTypeConstraints: StateConstraint = {
 }
 
 /**
+ * Age-specific LE constraints
+ * Remaining life expectancy at specific ages requires yearly-style periods.
+ * Keep sub-yearly LE available for the aggregate "all ages" view.
+ */
+const leSpecificAgeChartTypeConstraints: StateConstraint = {
+  when: (state) => {
+    if (state.type !== 'le') return false
+    const ageGroups = Array.isArray(state.ageGroups) ? state.ageGroups : []
+    const hasSpecificAgeGroups = ageGroups.length > 0 && !ageGroups.includes('all')
+    return hasSpecificAgeGroups
+      && !['yearly', 'midyear', 'fluseason'].includes(String(state.chartType ?? ''))
+  },
+  apply: {
+    chartType: 'yearly'
+  },
+  reason: 'Age-specific life expectancy is only available for yearly chart types',
+  allowUserOverride: false,
+  priority: 2
+}
+
+/**
  * Matrix chart style constraints
  * Matrix disables several features
  */
@@ -326,6 +347,7 @@ export const STATE_CONSTRAINTS: StateConstraint[] = [
   populationTypeConstraints,
   asmrTypeConstraints,
   asdChartTypeConstraints,
+  leSpecificAgeChartTypeConstraints,
   matrixStyleConstraints,
 
   // View synchronization (keep isExcess/isZScore in sync with view field)

--- a/app/lib/state/resolver/StateResolver.test.ts
+++ b/app/lib/state/resolver/StateResolver.test.ts
@@ -171,6 +171,29 @@ describe('StateResolver', () => {
       const chartStyleChange = resolved.log.changes.find(c => c.field === 'chartStyle')
       expect(chartStyleChange).toBeUndefined()
     })
+
+    it('should clear stale dates when LE age-specific URL constraints rewrite chartType', () => {
+      const route = createMockRoute({
+        t: 'le',
+        ct: 'weekly',
+        ag: ['40-49', '50-59'],
+        df: '2020 W01',
+        dt: '2024 W52',
+        bf: '2015 W01',
+        bt: '2019 W52'
+      })
+      const resolved = StateResolver.resolveInitial(route)
+
+      expect(resolved.state.type).toBe('le')
+      expect(resolved.state.chartType).toBe('yearly')
+      expect(resolved.state.ageGroups).toEqual(['40-49', '50-59'])
+      expect(resolved.state.dateFrom).toBeUndefined()
+      expect(resolved.state.dateTo).toBeUndefined()
+      expect(resolved.state.baselineDateFrom).toBeUndefined()
+      expect(resolved.state.baselineDateTo).toBeUndefined()
+      expect(resolved.userOverrides.has('dateFrom')).toBe(false)
+      expect(resolved.userOverrides.has('dateTo')).toBe(false)
+    })
   })
 
   describe('createSnapshot', () => {
@@ -539,6 +562,88 @@ describe('StateResolver', () => {
       // Non-overridden fields should get excess view defaults
       expect(resolved.state.chartStyle).toBe('bar') // excess default
       expect(resolved.state.showPercentage).toBe(true) // excess default
+    })
+
+    it('should reset maximize to mortality default when leaving excess view', () => {
+      const currentState = {
+        view: 'excess',
+        countries: ['USA'],
+        type: 'asmr',
+        chartType: 'fluseason',
+        chartStyle: 'bar',
+        maximize: true,
+        cumulative: false,
+        showBaseline: true,
+        showPredictionInterval: false,
+        showPercentage: true,
+        isExcess: true,
+        ageGroups: ['all']
+      }
+      const userOverrides = new Set(['maximize'])
+
+      const resolved = StateResolver.resolveViewChange('mortality', currentState, userOverrides)
+
+      expect(resolved.state.view).toBe('mortality')
+      expect(resolved.state.chartStyle).toBe('line')
+      expect(resolved.state.maximize).toBe(false)
+      expect(resolved.userOverrides.has('maximize')).toBe(false)
+    })
+  })
+
+  describe('resolveChange - metric driven chartType normalization', () => {
+    it('should force yearly chart type for age-specific LE and clear stale dates', () => {
+      const currentState = {
+        view: 'mortality',
+        countries: ['DEU'],
+        type: 'cmr',
+        chartType: 'weekly',
+        ageGroups: ['40-49', '50-59'],
+        dateFrom: '2020 W01',
+        dateTo: '2024 W52',
+        baselineDateFrom: '2015 W01',
+        baselineDateTo: '2019 W52',
+        showBaseline: false,
+        showPredictionInterval: false
+      }
+      const userOverrides = new Set(['ageGroups', 'dateFrom', 'dateTo', 'baselineDateFrom', 'baselineDateTo'])
+
+      const resolved = StateResolver.resolveChange(
+        { field: 'type', value: 'le', source: 'user' },
+        currentState,
+        userOverrides
+      )
+
+      expect(resolved.state.type).toBe('le')
+      expect(resolved.state.chartType).toBe('yearly')
+      expect(resolved.state.ageGroups).toEqual(['40-49', '50-59'])
+      expect(resolved.state.dateFrom).toBeUndefined()
+      expect(resolved.state.dateTo).toBeUndefined()
+      expect(resolved.state.baselineDateFrom).toBeUndefined()
+      expect(resolved.state.baselineDateTo).toBeUndefined()
+      expect(resolved.userOverrides.has('dateFrom')).toBe(false)
+      expect(resolved.userOverrides.has('dateTo')).toBe(false)
+    })
+
+    it('should preserve sub-yearly chart type for all-ages LE', () => {
+      const currentState = {
+        view: 'mortality',
+        countries: ['DEU'],
+        type: 'cmr',
+        chartType: 'weekly',
+        ageGroups: ['all'],
+        showBaseline: false,
+        showPredictionInterval: false
+      }
+
+      const resolved = StateResolver.resolveChange(
+        { field: 'type', value: 'le', source: 'user' },
+        currentState,
+        new Set()
+      )
+
+      expect(resolved.state.type).toBe('le')
+      expect(resolved.state.chartType).toBe('weekly')
+      expect(resolved.state.ageGroups).toEqual(['all'])
     })
   })
 

--- a/app/lib/state/resolver/StateResolver.ts
+++ b/app/lib/state/resolver/StateResolver.ts
@@ -45,8 +45,37 @@ function getViewDefaults(view: ViewType): Record<string, unknown> {
   }
 }
 
+const VIEW_OWNED_FIELDS_ON_SWITCH = new Set(['chartStyle', 'maximize'])
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class StateResolver {
+  private static clearDateFieldsForChartTypeChange(
+    state: Record<string, unknown>,
+    userOverrides: Set<string>,
+    log: StateResolutionLog,
+    oldChartType: unknown,
+    newChartType: unknown
+  ): void {
+    if (oldChartType === newChartType) return
+
+    const dateFields = ['dateFrom', 'dateTo', 'baselineDateFrom', 'baselineDateTo']
+    for (const field of dateFields) {
+      if (state[field] !== undefined) {
+        const fieldUrlKey = stateFieldEncoders[field as keyof typeof stateFieldEncoders]?.key || field
+        log.changes.push({
+          field,
+          urlKey: fieldUrlKey,
+          oldValue: state[field],
+          newValue: undefined,
+          priority: 'constraint',
+          reason: `Cleared: chartType changed from ${String(oldChartType)} to ${String(newChartType)}`
+        })
+        state[field] = undefined
+      }
+      userOverrides.delete(field)
+    }
+  }
+
   /**
    * Resolve initial state from URL parameters + defaults
    *
@@ -163,7 +192,15 @@ export class StateResolver {
     }
 
     // 5. Apply constraints (including view-specific constraints)
+    const chartTypeBeforeConstraints = state.chartType
     const constrainedState = this.applyConstraints(state, userOverrides, log)
+    this.clearDateFieldsForChartTypeChange(
+      constrainedState,
+      userOverrides,
+      log,
+      chartTypeBeforeConstraints,
+      constrainedState.chartType
+    )
 
     log.after = { ...constrainedState }
 
@@ -267,6 +304,13 @@ export class StateResolver {
 
     // 2. Apply constraints
     const constrainedState = this.applyConstraints(state, userOverrides, log)
+    this.clearDateFieldsForChartTypeChange(
+      constrainedState,
+      userOverrides,
+      log,
+      currentState.chartType,
+      constrainedState.chartType
+    )
 
     log.after = { ...constrainedState }
 
@@ -358,12 +402,11 @@ export class StateResolver {
     })
 
     // 2. Apply view defaults
-    // When switching views, chartStyle should always use the new view's default
-    // because chartStyle is set BY the view, not by explicit user action
+    // Some display fields are owned by the active view and should reset on view switch
+    // instead of staying sticky from the previous view's user overrides.
     const actualViewConfig = VIEWS[actualView]
     for (const [field, value] of Object.entries(actualViewConfig.defaults || {})) {
-      // Special case: chartStyle is always set by view defaults, not user override
-      const shouldApply = field === 'chartStyle' || !userOverrides.has(field)
+      const shouldApply = VIEW_OWNED_FIELDS_ON_SWITCH.has(field) || !userOverrides.has(field)
 
       if (shouldApply) {
         const oldValue = state[field]
@@ -381,9 +424,9 @@ export class StateResolver {
           })
         }
 
-        // Remove chartStyle from userOverrides since it's controlled by view
-        if (field === 'chartStyle') {
-          userOverrides.delete('chartStyle')
+        // Remove view-owned fields from userOverrides since the target view controls them.
+        if (VIEW_OWNED_FIELDS_ON_SWITCH.has(field)) {
+          userOverrides.delete(field)
         }
       }
     }


### PR DESCRIPTION
## Summary
- reset `maximize` when switching from Excess back to Raw/Mortality so `m=1` does not stay sticky
- normalize age-specific LE off sub-yearly chart types onto yearly chart types and clear stale date params when that rewrite happens
- add resolver/constraint regression tests for both paths, including initial URL resolution

## Fixes
- Closes #538
- Closes #539

## Testing
- `pnpm exec nuxi prepare`
- `pnpm vitest run app/lib/state/config/constraints.test.ts app/lib/state/resolver/StateResolver.test.ts app/lib/state/normalizeLeAgeGroups.test.ts`

## Note on #540
Issue #540 was investigated separately and commented with the current diagnosis. It looks like a published data / pipeline-source-handoff problem rather than a frontend state bug, so it is not included in this PR.
