### PR TITLE
Fix France LE stitched-series rendering and auto lambda requests

### DIFF
--- a/app/components/explorer/DataSourcesDisplay.vue
+++ b/app/components/explorer/DataSourcesDisplay.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { CountrySourceInfo } from '@/composables/useExplorerDataOrchestration'
 import type { Country } from '@/model'
+import type { CountrySourceInfo, SourceSegment } from '@/lib/explorer/sourceInfo'
 
 const props = defineProps<{
   /** Map of country ISO3C code to source info */
@@ -36,18 +36,27 @@ const getCountryName = (iso3c: string): string => {
   return props.allCountries[iso3c]?.jurisdiction || iso3c
 }
 
-/**
- * Format age groups for display
- */
 const formatAgeGroups = (ageGroups: string[]): string => {
-  if (!ageGroups || ageGroups.length === 0) return ''
-  // Sort numerically by first number in range
-  const sorted = [...ageGroups].sort((a, b) => {
+  return [...ageGroups].sort((a, b) => {
     const numA = parseInt(a.split('-')[0] || a.replace('+', '')) || 0
     const numB = parseInt(b.split('-')[0] || b.replace('+', '')) || 0
     return numA - numB
-  })
-  return sorted.join(', ')
+  }).join(', ')
+}
+
+const formatSegmentDateRange = (segment: SourceSegment): string => {
+  if (segment.from === segment.to) return segment.from
+  return `${segment.from}-${segment.to}`
+}
+
+const formatSegment = (segment: SourceSegment): string => {
+  const parts = [`${formatSourceName(segment.source)} (${formatSegmentDateRange(segment)}`]
+
+  if (showAgeGroupsInline.value && segment.ageGroups && segment.ageGroups.length > 0) {
+    parts.push(formatAgeGroups(segment.ageGroups).replace(/, /g, '/'))
+  }
+
+  return `${parts.join(', ')})`
 }
 
 /**
@@ -76,12 +85,24 @@ const isSingleSource = computed(() => {
   return groupedBySource.value.size === 1
 })
 
+const hasSegmentedSources = computed(() => {
+  return [...props.sourceInfo.values()].some(info => info.segments.length > 1)
+})
+
+const showAgeGroupsInline = computed(() => {
+  return !!props.showAgeGroups
+})
+
 /**
  * Get the first source info for single-source display
  */
 const firstSourceInfo = computed(() => {
   const values = [...props.sourceInfo.values()]
   return values[0]
+})
+
+const countryEntries = computed(() => {
+  return [...props.sourceInfo.entries()]
 })
 </script>
 
@@ -97,7 +118,7 @@ const firstSourceInfo = computed(() => {
       </div>
 
       <!-- Source info -->
-      <template v-if="isSingleSource && firstSourceInfo">
+      <template v-if="!hasSegmentedSources && isSingleSource && firstSourceInfo">
         <!-- Single source for all countries -->
         <div>
           {{ formatSourceName(firstSourceInfo.source) }}
@@ -111,7 +132,7 @@ const firstSourceInfo = computed(() => {
         </div>
       </template>
 
-      <template v-else>
+      <template v-else-if="!hasSegmentedSources">
         <!-- Multiple sources - list by source -->
         <div class="space-y-1">
           <div
@@ -127,6 +148,27 @@ const firstSourceInfo = computed(() => {
               class="ml-2 text-gray-400 dark:text-gray-500"
             >
               Age stratification: {{ formatAgeGroups(group.ageGroups) }}
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template v-else>
+        <div class="space-y-1">
+          <div
+            v-for="[iso3c, info] in countryEntries"
+            :key="iso3c"
+          >
+            <div>
+              <span class="font-medium">{{ getCountryName(iso3c) }}:</span>
+              {{ info.segments.map(formatSegment).join('; ') }}
+            </div>
+            <div
+              v-for="warning in info.breakpointWarnings"
+              :key="warning"
+              class="ml-2 text-amber-700 dark:text-amber-400"
+            >
+              {{ warning }}
             </div>
           </div>
         </div>

--- a/app/composables/useExplorerDataOrchestration.ts
+++ b/app/composables/useExplorerDataOrchestration.ts
@@ -253,15 +253,15 @@ export function useExplorerDataOrchestration(
     const needsAgeGroups = metricType === 'asmr' || metricType === 'le'
     const chartType = state.chartType.value as ChartType
 
-    let metadataLoaded = false
+    let metadataLoadPromise: Promise<void> | null = null
     const getSourceAgeGroups = async (country: string) => {
       if (!needsAgeGroups) return new Map<string, string[]>()
 
       try {
-        if (!metadataLoaded) {
-          await metadataService.load()
-          metadataLoaded = true
+        if (!metadataLoadPromise) {
+          metadataLoadPromise = metadataService.load()
         }
+        await metadataLoadPromise
 
         return metadataService.getSourcesWithAgeGroups(country, chartType)
       } catch {

--- a/app/composables/useExplorerDataOrchestration.ts
+++ b/app/composables/useExplorerDataOrchestration.ts
@@ -45,16 +45,10 @@ import {
 } from '@/lib/state/resolution'
 import { logger } from '@/lib/logger'
 import { getUniqueYears } from '@/lib/utils/dates'
-
-/**
- * Source information for a country's data
- */
-export interface CountrySourceInfo {
-  /** Data source name (e.g., "eurostat", "cdc", "un") */
-  source: string
-  /** Age groups used for age-stratified calculations (ASD, ASMR, LE) */
-  ageGroups?: string[]
-}
+import {
+  extractSourceInfoFromDataset,
+  type CountrySourceInfo
+} from '@/lib/explorer/sourceInfo'
 
 /**
  * Map of country ISO3C code → raw `le_unavailable_reason` string from the
@@ -248,76 +242,41 @@ export function useExplorerDataOrchestration(
    *
    * Also fetches age groups from metadata for age-stratified metrics (ASMR, LE).
    */
-  const extractSourcesFromDataset = async (datasetToExtract: DatasetRaw, countries: string[]) => {
+  const extractSourcesFromDataset = async (
+    datasetToExtract: DatasetRaw,
+    countries: string[],
+    selectedLabels?: string[]
+  ) => {
     // Don't overwrite ASD source info
     if (state.type.value === 'asd') return
-
-    const sources = new Map<string, CountrySourceInfo>()
     const metricType = state.type.value
-    const isAsmrMetric = metricType === 'asmr'
-    const isLeMetric = metricType === 'le'
+    const needsAgeGroups = metricType === 'asmr' || metricType === 'le'
     const chartType = state.chartType.value as ChartType
 
-    // For age-stratified metrics, get age groups from metadata
-    const needsAgeGroups = isAsmrMetric || isLeMetric
+    let metadataLoaded = false
+    const getSourceAgeGroups = async (country: string) => {
+      if (!needsAgeGroups) return new Map<string, string[]>()
 
-    // Pre-fetch source -> age groups mapping for all countries if needed
-    const sourceAgeGroupsMap = new Map<string, Map<string, string[]>>()
-    if (needsAgeGroups) {
       try {
-        // Ensure metadata is loaded before accessing
-        await metadataService.load()
-        for (const country of countries) {
-          sourceAgeGroupsMap.set(country, metadataService.getSourcesWithAgeGroups(country, chartType))
+        if (!metadataLoaded) {
+          await metadataService.load()
+          metadataLoaded = true
         }
+
+        return metadataService.getSourcesWithAgeGroups(country, chartType)
       } catch {
         log.warn('Could not load metadata for age groups')
+        return new Map<string, string[]>()
       }
     }
 
-    for (const country of countries) {
-      // Look through age groups to find data for this country
-      for (const ageGroup of Object.keys(datasetToExtract)) {
-        const countryData = datasetToExtract[ageGroup]?.[country]
-        if (countryData && countryData.length > 0) {
-          // Get source from the most recent data row
-          // Use source_asmr for ASMR metrics, otherwise use source
-          for (let i = countryData.length - 1; i >= 0; i--) {
-            const row = countryData[i]
-            if (row) {
-              const sourceValue = isAsmrMetric ? (row.source_asmr || row.source) : row.source
-              if (sourceValue) {
-                const sourceInfo: CountrySourceInfo = { source: sourceValue }
-
-                // Get age groups for the specific source used
-                if (needsAgeGroups) {
-                  const countrySourcesMap = sourceAgeGroupsMap.get(country)
-                  let ageGroups = countrySourcesMap?.get(sourceValue)
-
-                  // Fallback: if source not found in map, try getBestSourceForCountry
-                  if (!ageGroups || ageGroups.length === 0) {
-                    const bestSource = metadataService.getBestSourceForCountry(country, chartType)
-                    if (bestSource?.ageGroups) {
-                      ageGroups = bestSource.ageGroups
-                    }
-                  }
-
-                  if (ageGroups && ageGroups.length > 0) {
-                    sourceInfo.ageGroups = ageGroups
-                  }
-                }
-
-                sources.set(country, sourceInfo)
-                break
-              }
-            }
-          }
-          if (sources.has(country)) break
-        }
-      }
-    }
-
-    dataSourceInfo.value = sources
+    dataSourceInfo.value = await extractSourceInfoFromDataset(
+      datasetToExtract,
+      countries,
+      metricType,
+      selectedLabels,
+      needsAgeGroups ? getSourceAgeGroups : undefined
+    )
   }
 
   /**
@@ -415,7 +374,19 @@ export function useExplorerDataOrchestration(
         const { source, ageGroups } = sourceInfo
 
         // Track source info for display below chart
-        asdSourceInfo.set(country, { source, ageGroups })
+        asdSourceInfo.set(country, {
+          source,
+          ageGroups,
+          segments: [
+            {
+              source,
+              from: 'Available range',
+              to: 'Available range',
+              ageGroups
+            }
+          ],
+          breakpointWarnings: []
+        })
 
         const result = await asdDataComposable.fetchASDForCountry(
           country,
@@ -971,9 +942,6 @@ export function useExplorerDataOrchestration(
         Object.assign(allChartData, result.chartData)
       }
 
-      // Extract source info from dataset for display below chart
-      await extractSourcesFromDataset(dataset, state.countries.value)
-
       // Surface any LE-unavailability reasons from the loaded rows (no-op
       // unless the LE metric is selected and rows carry the column).
       extractLeUnavailableReasons(dataset, state.countries.value)
@@ -1019,9 +987,6 @@ export function useExplorerDataOrchestration(
         Object.assign(allChartData, result.chartData)
       }
 
-      // Extract source info from dataset for display below chart
-      await extractSourcesFromDataset(dataset, state.countries.value)
-
       // Surface any LE-unavailability reasons from the loaded rows (no-op
       // unless the LE metric is selected and rows carry the column).
       extractLeUnavailableReasons(dataset, state.countries.value)
@@ -1035,6 +1000,15 @@ export function useExplorerDataOrchestration(
     // Pass snapshot if provided for consistent rendering during view transitions
     const filteredData = await updateFilteredData(snapshot)
     chartData.value = filteredData as MortalityChartData
+
+    // Extract source info for the rendered label range after chart filtering is applied.
+    if (dataset) {
+      await extractSourcesFromDataset(
+        dataset,
+        state.countries.value,
+        filteredData.labels
+      )
+    }
 
     configureOptions()
 

--- a/app/lib/baseline/calculateBaseline.test.ts
+++ b/app/lib/baseline/calculateBaseline.test.ts
@@ -264,4 +264,77 @@ describe('calculateBaseline', () => {
       expect(data.le_zscore).toEqual([undefined, undefined, 0.1, 0.2, 0.3, 0.4])
     })
   })
+
+  describe('variance-stabilized lambda mode request shaping', () => {
+    it('omits lambda fields for auto mode', async () => {
+      const mockResponse = {
+        y: [81, 81, 81, 81],
+        lower: [null, null, null, 79],
+        upper: [null, null, null, 83],
+        zscore: [0, 0.5, 1, 1.5]
+      }
+
+      const deps = createMockDeps(mockResponse)
+
+      const data: DatasetEntry = {
+        le: [80, 81, 82, 83]
+      } as unknown as DatasetEntry
+
+      await calculateBaseline(
+        deps,
+        data,
+        ['2017', '2018', '2019', '2020'],
+        0,
+        2,
+        ['le', 'le_baseline', 'le_baseline_lower', 'le_baseline_upper'] as (keyof DatasetEntry)[],
+        'mean',
+        'yearly',
+        false,
+        undefined,
+        'variance_stabilized',
+        'auto',
+        '1'
+      )
+
+      const fetchBody = (deps.fetchBaseline as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as Record<string, unknown>
+      expect(fetchBody.zscore_method).toBe('variance_stabilized')
+      expect(fetchBody).not.toHaveProperty('lambda_mode')
+      expect(fetchBody).not.toHaveProperty('lambda')
+    })
+
+    it('includes lambda fields for manual mode', async () => {
+      const mockResponse = {
+        y: [81, 81, 81, 81],
+        lower: [null, null, null, 79],
+        upper: [null, null, null, 83],
+        zscore: [0, 0.5, 1, 1.5]
+      }
+
+      const deps = createMockDeps(mockResponse)
+
+      const data: DatasetEntry = {
+        le: [80, 81, 82, 83]
+      } as unknown as DatasetEntry
+
+      await calculateBaseline(
+        deps,
+        data,
+        ['2017', '2018', '2019', '2020'],
+        0,
+        2,
+        ['le', 'le_baseline', 'le_baseline_lower', 'le_baseline_upper'] as (keyof DatasetEntry)[],
+        'mean',
+        'yearly',
+        false,
+        undefined,
+        'variance_stabilized',
+        'manual',
+        '1'
+      )
+
+      const fetchBody = (deps.fetchBaseline as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as Record<string, unknown>
+      expect(fetchBody.lambda_mode).toBe('manual')
+      expect(fetchBody.lambda).toBe(1)
+    })
+  })
 })

--- a/app/lib/baseline/calculateBaseline.ts
+++ b/app/lib/baseline/calculateBaseline.ts
@@ -217,8 +217,11 @@ export const calculateBaseline = async (
     }
 
     if (zscoreMethod === 'variance_stabilized') {
-      body.lambda_mode = zscoreLambdaMode
+      // The stats API treats an omitted lambda mode as automatic selection.
+      // Sending lambda_mode='auto' currently 400s unless a numeric lambda is
+      // also provided, so only send these fields for explicit manual mode.
       if (zscoreLambdaMode === 'manual' && zscoreLambda) {
+        body.lambda_mode = 'manual'
         body.lambda = Number(zscoreLambda)
       }
     }

--- a/app/lib/chart/datasets.test.ts
+++ b/app/lib/chart/datasets.test.ts
@@ -128,6 +128,30 @@ describe('datasets', () => {
 
       expect(result.sources).toContain('Source 1')
     })
+
+    it('should split life expectancy line datasets at source transitions', () => {
+      const config = createBaseConfig()
+      config.chart.type = 'le'
+      config.chart.chartType = 'yearly'
+
+      const data: Dataset = {
+        all: {
+          USA: createMockDatasetEntry({
+            date: ['2011', '2012', '2013', '2014'],
+            source: ['mortality_org', 'mortality_org', 'eurostat', 'eurostat'],
+            le: [80.2, 80.5, 82.9, 83.3] as NumberArray
+          })
+        }
+      }
+
+      const result = getDatasets(config, data)
+
+      expect(result.datasets).toHaveLength(2)
+      expect(result.datasets[0]?.label).toContain('United States')
+      expect(result.datasets[1]?.label).toBe('')
+      expect(result.datasets[0]?.data).toEqual([80.2, 80.5, null, null])
+      expect(result.datasets[1]?.data).toEqual([null, null, 82.9, 83.3])
+    })
   })
 
   describe('getDatasets - multiple countries', () => {

--- a/app/lib/chart/datasets.ts
+++ b/app/lib/chart/datasets.ts
@@ -88,6 +88,68 @@ const getType = (
   return undefined
 }
 
+const shouldSegmentLifeExpectancySeries = (
+  config: DataTransformationConfig,
+  key: string
+) => {
+  return !config.chart.isBarChartStyle
+    && !config.chart.isMatrixChartStyle
+    && config.display.view === 'mortality'
+    && (key === 'le' || key === 'le_adj')
+}
+
+const normalizeSourceSeries = (
+  sourceValues: unknown[],
+  expectedLength: number
+): string[] | null => {
+  if (sourceValues.length === expectedLength) {
+    return sourceValues.map(value => typeof value === 'string' ? value : '')
+  }
+
+  if (sourceValues.length === 1) {
+    const value = typeof sourceValues[0] === 'string' ? sourceValues[0] : ''
+    return new Array(expectedLength).fill(value)
+  }
+
+  return null
+}
+
+const splitSeriesBySourceTransitions = (
+  dataPoints: DefaultDataPoint<ChartType>,
+  sourceValues: unknown[]
+): DefaultDataPoint<ChartType>[] => {
+  if (!Array.isArray(dataPoints) || dataPoints.length <= 1) return [dataPoints]
+
+  const normalizedSources = normalizeSourceSeries(sourceValues, dataPoints.length)
+  if (!normalizedSources) return [dataPoints]
+
+  const transitionIndexes: number[] = []
+  for (let i = 1; i < normalizedSources.length; i++) {
+    const previous = normalizedSources[i - 1]
+    const current = normalizedSources[i]
+    if (previous && current && previous !== current) {
+      transitionIndexes.push(i)
+    }
+  }
+
+  if (transitionIndexes.length === 0) return [dataPoints]
+
+  const segments: DefaultDataPoint<ChartType>[] = []
+  let segmentStart = 0
+  const boundaries = [...transitionIndexes, dataPoints.length]
+
+  for (const segmentEnd of boundaries) {
+    const segment = new Array(dataPoints.length).fill(null)
+    for (let i = segmentStart; i < segmentEnd; i++) {
+      segment[i] = dataPoints[i]
+    }
+    segments.push(segment as DefaultDataPoint<ChartType>)
+    segmentStart = segmentEnd
+  }
+
+  return segments
+}
+
 const getSource = (ds: Record<string, unknown[]>, key: string) => {
   if (key.startsWith('asmr') && ds['source_asmr']) {
     return ds.source_asmr
@@ -271,35 +333,44 @@ export const getDatasets = (
                   dsRecord as Record<string, number[]>,
                   key
                 ))
-        datasets.push({
-          label,
-          data: transformedData,
-          borderColor: config.visual.colors[countryIndex],
-          backgroundColor: getBackgroundColor(key, color),
-          fill: fillTarget,
-          borderWidth: getBorderWidth(key, config.chart.isBarChartStyle),
-          borderDash: getBorderDash(key),
-          pointRadius:
-            config.context.countries.length * ags.length > 5
-              ? 0
-              : getPointRadius(config.chart.chartType, key),
-          pointBackgroundColor: getPointBackgroundColor(key, color),
-          type: getType(
-            key,
-            config.chart.isBarChartStyle || isPopulationComposition,
-            config.chart.isExcess,
-            config.display.showPredictionInterval
-          ),
-          stack: isPopulationComposition ? iso3c : undefined,
-          hidden: isPredictionIntervalKey(key) && !config.display.showPredictionInterval,
-          zscoreMeta: config.display.view === 'zscore' && label
-            ? {
-                series: config.context.baselineMetadata?.[
-                  getBaselineMetadataKey(ag, iso3c, key)
-                ]
-              }
-            : undefined
-        } as ChartDataset<ChartType, DefaultDataPoint<ChartType>> & ZScoreDatasetMeta)
+        const segmentedSeries = shouldSegmentLifeExpectancySeries(config, key)
+          ? splitSeriesBySourceTransitions(
+              transformedData,
+              (dsRecord.source as unknown[]) ?? []
+            )
+          : [transformedData]
+
+        segmentedSeries.forEach((segmentData, segmentIndex) => {
+          datasets.push({
+            label: segmentIndex === 0 ? label : '',
+            data: segmentData,
+            borderColor: config.visual.colors[countryIndex],
+            backgroundColor: getBackgroundColor(key, color),
+            fill: fillTarget,
+            borderWidth: getBorderWidth(key, config.chart.isBarChartStyle),
+            borderDash: getBorderDash(key),
+            pointRadius:
+              config.context.countries.length * ags.length > 5
+                ? 0
+                : getPointRadius(config.chart.chartType, key),
+            pointBackgroundColor: getPointBackgroundColor(key, color),
+            type: getType(
+              key,
+              config.chart.isBarChartStyle || isPopulationComposition,
+              config.chart.isExcess,
+              config.display.showPredictionInterval
+            ),
+            stack: isPopulationComposition ? iso3c : undefined,
+            hidden: isPredictionIntervalKey(key) && !config.display.showPredictionInterval,
+            zscoreMeta: config.display.view === 'zscore' && label
+              ? {
+                  series: config.context.baselineMetadata?.[
+                    getBaselineMetadataKey(ag, iso3c, key)
+                  ]
+                }
+              : undefined
+          } as ChartDataset<ChartType, DefaultDataPoint<ChartType>> & ZScoreDatasetMeta)
+        })
       })
       countryIndex++
     }

--- a/app/lib/explorer/sourceInfo.test.ts
+++ b/app/lib/explorer/sourceInfo.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { CountryData, DatasetRaw } from '@/model'
+import {
+  extractCountrySourceInfoFromSeries,
+  extractSourceInfoFromDataset
+} from './sourceInfo'
+
+function makeRow(
+  date: string,
+  source: string,
+  sourceAsmr: string = ''
+): CountryData {
+  return {
+    date,
+    source,
+    source_asmr: sourceAsmr
+  } as CountryData
+}
+
+describe('sourceInfo helpers', () => {
+  it('extracts stitched source segments for life expectancy within the selected range', () => {
+    const rows = [
+      makeRow('2000', 'mortality_org'),
+      makeRow('2001', 'mortality_org'),
+      makeRow('2012', 'mortality_org'),
+      makeRow('2013', 'eurostat'),
+      makeRow('2025', 'eurostat')
+    ]
+
+    const info = extractCountrySourceInfoFromSeries(
+      rows,
+      'le',
+      ['2001', '2012', '2013', '2025'],
+      new Map([
+        ['mortality_org', ['0-14', '15-64', '65-74', '75-84', '85+']],
+        ['eurostat', ['0-9', '10-19', '20-29', '30-39', '40-49', '50-59', '60-69', '70-79', '80+']]
+      ])
+    )
+
+    expect(info).not.toBeNull()
+    expect(info?.segments).toEqual([
+      {
+        source: 'mortality_org',
+        from: '2001',
+        to: '2012',
+        ageGroups: ['0-14', '15-64', '65-74', '75-84', '85+']
+      },
+      {
+        source: 'eurostat',
+        from: '2013',
+        to: '2025',
+        ageGroups: ['0-9', '10-19', '20-29', '30-39', '40-49', '50-59', '60-69', '70-79', '80+']
+      }
+    ])
+    expect(info?.breakpointWarnings).toEqual([
+      'Warning: source and age stratification change in 2013; values across the breakpoint may not be directly comparable.'
+    ])
+  })
+
+  it('falls back to asmr-specific source values when extracting ASMR provenance', () => {
+    const rows = [
+      makeRow('2020', 'mortality_org', 'who'),
+      makeRow('2021', 'mortality_org', 'who')
+    ]
+
+    const info = extractCountrySourceInfoFromSeries(rows, 'asmr')
+
+    expect(info?.source).toBe('who')
+    expect(info?.segments).toEqual([
+      {
+        source: 'who',
+        from: '2020',
+        to: '2021',
+        ageGroups: undefined
+      }
+    ])
+  })
+
+  it('extracts per-country source info from a dataset using the rendered labels', async () => {
+    const dataset: DatasetRaw = {
+      all: {
+        FRA: [
+          makeRow('2012', 'mortality_org'),
+          makeRow('2013', 'eurostat'),
+          makeRow('2014', 'eurostat')
+        ]
+      }
+    }
+
+    const result = await extractSourceInfoFromDataset(
+      dataset,
+      ['FRA'],
+      'le',
+      ['2013', '2014'],
+      async () => new Map([
+        ['mortality_org', ['0-14', '15-64', '65-74', '75-84', '85+']],
+        ['eurostat', ['0-9', '10-19', '20-29', '30-39', '40-49', '50-59', '60-69', '70-79', '80+']]
+      ])
+    )
+
+    expect(result.get('FRA')?.segments).toEqual([
+      {
+        source: 'eurostat',
+        from: '2013',
+        to: '2014',
+        ageGroups: ['0-9', '10-19', '20-29', '30-39', '40-49', '50-59', '60-69', '70-79', '80+']
+      }
+    ])
+  })
+})

--- a/app/lib/explorer/sourceInfo.ts
+++ b/app/lib/explorer/sourceInfo.ts
@@ -1,0 +1,148 @@
+import type { CountryData, DatasetRaw } from '@/model'
+
+export interface SourceSegment {
+  source: string
+  from: string
+  to: string
+  ageGroups?: string[]
+}
+
+export interface CountrySourceInfo {
+  source: string
+  ageGroups?: string[]
+  segments: SourceSegment[]
+  breakpointWarnings: string[]
+}
+
+function sortAgeGroups(ageGroups?: string[]): string[] | undefined {
+  if (!ageGroups || ageGroups.length === 0) return undefined
+
+  return [...ageGroups].sort((a, b) => {
+    const numA = parseInt(a.split('-')[0] || a.replace('+', '')) || 0
+    const numB = parseInt(b.split('-')[0] || b.replace('+', '')) || 0
+    return numA - numB
+  })
+}
+
+function getSourceValue(row: CountryData, metricType: string): string | undefined {
+  if (metricType === 'asmr') {
+    return row.source_asmr || row.source || undefined
+  }
+
+  return row.source || undefined
+}
+
+function buildBreakpointWarning(segments: SourceSegment[]): string[] {
+  if (segments.length <= 1) return []
+
+  const uniqueSources = new Set(segments.map(segment => segment.source))
+  const uniqueAgeSchemas = new Set(
+    segments.map(segment => JSON.stringify(segment.ageGroups ?? []))
+  )
+  const breakpoint = segments[1]?.from
+
+  if (!breakpoint) return []
+
+  const changedParts: string[] = []
+  if (uniqueSources.size > 1) changedParts.push('source')
+  if (uniqueAgeSchemas.size > 1) changedParts.push('age stratification')
+
+  if (changedParts.length === 0) return []
+
+  return [
+    `Warning: ${changedParts.join(' and ')} change in ${breakpoint}; values across the breakpoint may not be directly comparable.`
+  ]
+}
+
+export function extractCountrySourceInfoFromSeries(
+  rows: CountryData[],
+  metricType: string,
+  selectedLabels?: string[],
+  sourceAgeGroups?: Map<string, string[]>
+): CountrySourceInfo | null {
+  const selectedLabelSet = selectedLabels?.length ? new Set(selectedLabels) : null
+  const candidateRows = rows.filter((row) => {
+    const source = getSourceValue(row, metricType)
+    if (!source) return false
+    if (!selectedLabelSet) return true
+    return selectedLabelSet.has(row.date)
+  })
+
+  const rowsToUse = candidateRows.length > 0
+    ? candidateRows
+    : rows.filter(row => !!getSourceValue(row, metricType))
+
+  if (rowsToUse.length === 0) return null
+
+  const segments: SourceSegment[] = []
+
+  for (const row of rowsToUse) {
+    const source = getSourceValue(row, metricType)
+    if (!source) continue
+
+    const ageGroups = sortAgeGroups(sourceAgeGroups?.get(source))
+    const previousSegment = segments[segments.length - 1]
+    const ageGroupsKey = JSON.stringify(ageGroups ?? [])
+    const previousAgeGroupsKey = JSON.stringify(previousSegment?.ageGroups ?? [])
+
+    if (
+      previousSegment
+      && previousSegment.source === source
+      && ageGroupsKey === previousAgeGroupsKey
+    ) {
+      previousSegment.to = row.date
+      continue
+    }
+
+    segments.push({
+      source,
+      from: row.date,
+      to: row.date,
+      ageGroups
+    })
+  }
+
+  if (segments.length === 0) return null
+
+  const latestSegment = segments[segments.length - 1]!
+
+  return {
+    source: latestSegment.source,
+    ageGroups: latestSegment.ageGroups,
+    segments,
+    breakpointWarnings: buildBreakpointWarning(segments)
+  }
+}
+
+export async function extractSourceInfoFromDataset(
+  dataset: DatasetRaw,
+  countries: string[],
+  metricType: string,
+  selectedLabels?: string[],
+  getSourceAgeGroups?: (country: string) => Promise<Map<string, string[]>>
+): Promise<Map<string, CountrySourceInfo>> {
+  const result = new Map<string, CountrySourceInfo>()
+
+  for (const country of countries) {
+    const sourceAgeGroups = getSourceAgeGroups ? await getSourceAgeGroups(country) : undefined
+
+    for (const ageGroup of Object.keys(dataset)) {
+      const rows = dataset[ageGroup]?.[country]
+      if (!rows || rows.length === 0) continue
+
+      const info = extractCountrySourceInfoFromSeries(
+        rows,
+        metricType,
+        selectedLabels,
+        sourceAgeGroups
+      )
+
+      if (info) {
+        result.set(country, info)
+        break
+      }
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary
- show stitched Explorer source provenance with per-range source and age-schema notes
- warn when a rendered series crosses a source or age-stratification breakpoint
- break LE line rendering at source transitions so stitched series are not drawn as one continuous line
- stop sending `lambda_mode=auto` to the stats API for variance-stabilized z-scores, since that request shape currently returns HTTP 400

## Why
- France yearly LE currently shows a visible step across a stitched source/schema boundary (#540)
- Explorer previously hid that provenance change in the notes UI (#543)
- Variance-stabilized z-scores with auto lambda fail while manual lambda works

## Verification
- `npx vitest run app/lib/baseline/calculateBaseline.test.ts app/lib/chart/datasets.test.ts app/lib/explorer/sourceInfo.test.ts`
- live stats API reproduction confirmed `lambda_mode=auto` 400s while omitted mode succeeds and manual mode succeeds
- `npm run typecheck` is currently blocked on an unrelated existing Stripe type mismatch on `master`

Closes #543
Related: #540