### PR TITLE
Fix LE line breaks across overlapping source transitions

### DIFF
--- a/app/lib/chart/datasets.test.ts
+++ b/app/lib/chart/datasets.test.ts
@@ -152,6 +152,33 @@ describe('datasets', () => {
       expect(result.datasets[0]?.data).toEqual([80.2, 80.5, null, null])
       expect(result.datasets[1]?.data).toEqual([null, null, 82.9, 83.3])
     })
+
+    it('should keep life expectancy lines connected across overlapping source transitions', () => {
+      const config = createBaseConfig()
+      config.chart.type = 'le'
+      config.chart.chartType = 'yearly'
+
+      const data: Dataset = {
+        all: {
+          USA: createMockDatasetEntry({
+            date: ['2011', '2012', '2013', '2014'],
+            source: [
+              'mortality_org',
+              'mortality_org, eurostat',
+              'eurostat',
+              'eurostat'
+            ],
+            le: [80.2, 80.5, 82.9, 83.3] as NumberArray
+          })
+        }
+      }
+
+      const result = getDatasets(config, data)
+
+      expect(result.datasets).toHaveLength(1)
+      expect(result.datasets[0]?.label).toContain('United States')
+      expect(result.datasets[0]?.data).toEqual([80.2, 80.5, 82.9, 83.3])
+    })
   })
 
   describe('getDatasets - multiple countries', () => {

--- a/app/lib/chart/datasets.ts
+++ b/app/lib/chart/datasets.ts
@@ -114,6 +114,30 @@ const normalizeSourceSeries = (
   return null
 }
 
+const tokenizeSources = (value: string): Set<string> => {
+  return new Set(
+    value
+      .split(',')
+      .map(part => part.trim())
+      .filter(Boolean)
+  )
+}
+
+const shouldSplitAtSourceTransition = (previous: string, current: string): boolean => {
+  if (!previous || !current || previous === current) return false
+
+  const previousSources = tokenizeSources(previous)
+  const currentSources = tokenizeSources(current)
+
+  if (previousSources.size === 0 || currentSources.size === 0) return false
+
+  for (const source of previousSources) {
+    if (currentSources.has(source)) return false
+  }
+
+  return true
+}
+
 const splitSeriesBySourceTransitions = (
   dataPoints: DefaultDataPoint<ChartType>,
   sourceValues: unknown[]
@@ -127,7 +151,7 @@ const splitSeriesBySourceTransitions = (
   for (let i = 1; i < normalizedSources.length; i++) {
     const previous = normalizedSources[i - 1]
     const current = normalizedSources[i]
-    if (previous && current && previous !== current) {
+    if (shouldSplitAtSourceTransition(previous, current)) {
       transitionIndexes.push(i)
     }
   }

--- a/app/lib/chart/datasets.ts
+++ b/app/lib/chart/datasets.ts
@@ -151,6 +151,7 @@ const splitSeriesBySourceTransitions = (
   for (let i = 1; i < normalizedSources.length; i++) {
     const previous = normalizedSources[i - 1]
     const current = normalizedSources[i]
+    if (previous === undefined || current === undefined) continue
     if (shouldSplitAtSourceTransition(previous, current)) {
       transitionIndexes.push(i)
     }


### PR DESCRIPTION
## Summary
- keep life expectancy lines connected when adjacent points share at least one overlapping source
- still split the line for true disjoint source changes
- add a regression test covering the France-style overlap transition

## Testing
- `npx vitest run app/lib/chart/datasets.test.ts`

Closes #545
