### PR TITLE
Fix SSR chart fallback for missing default aggregation

### DIFF
--- a/server/routes/chart.png.ts
+++ b/server/routes/chart.png.ts
@@ -14,10 +14,12 @@ import {
   applySteepDropAdjustment,
   isChartDataEmpty
 } from '../utils/chartPngHelpers'
-import { dataLoader } from '../services/dataLoader'
+import { loadInitialChartDataForRendering } from '../utils/chartInitialData'
 import { renderChart } from '../utils/chartRenderer'
 import { setServerDarkMode } from '../../app/composables/useTheme'
 import { getOrCreateShortUrl } from '../utils/urlShortener'
+
+const CHART_RENDER_CACHE_VERSION = 'ssr-chart-type-fallback-v1'
 
 /**
  * Server-side chart PNG rendering endpoint
@@ -71,7 +73,15 @@ export default defineEventHandler(async (event) => {
     const zoom = getZoomLevel(query as Record<string, unknown>)
 
     // Generate cache key from query parameters (including width/height, dark mode, dp, and zoom)
-    const cacheKey = generateCacheKey({ ...queryParams, width, height, dm: darkMode ? '1' : '0', dp: devicePixelRatio, z: zoom })
+    const cacheKey = generateCacheKey({
+      ...queryParams,
+      width,
+      height,
+      dm: darkMode ? '1' : '0',
+      dp: devicePixelRatio,
+      z: zoom,
+      rv: CHART_RENDER_CACHE_VERSION
+    })
 
     // Allow bypassing cache with ?nocache=1 (useful for development)
     const noCache = queryParams.nocache === '1' || queryParams.nocache === 'true'
@@ -89,46 +99,33 @@ export default defineEventHandler(async (event) => {
     // Queue the chart rendering to limit concurrency
     const buffer = await chartRenderQueue.enqueue(async () => {
       try {
-        // Step 1: Do preliminary state resolution to get data loading params
-        // We need allLabels to compute effective date range, but we need
-        // countries/chartType/ageGroups to load data first
-        const preliminaryState = resolveChartStateForRendering(queryParams, [])
-
-        // Step 2: Load data to get allLabels
-        const rawData = await dataLoader.loadMortalityData({
-          chartType: preliminaryState.chartType,
-          countries: preliminaryState.countries,
-          ageGroups: preliminaryState.ageGroups
-        })
-
-        const isAsmrType = preliminaryState.type.startsWith('asmr')
-        const allLabels = dataLoader.getAllChartLabels(
-          rawData,
-          isAsmrType,
-          preliminaryState.ageGroups,
-          preliminaryState.countries,
-          preliminaryState.chartType
-        )
-
-        // Validate that we have data to render
-        if (allLabels.length === 0) {
-          const countriesStr = preliminaryState.countries.join(', ')
-          throw new Error(
-            `No data available for ${countriesStr} (${preliminaryState.chartType}). `
-            + 'The requested data may not exist or failed to load.'
-          )
-        }
+        // Step 1/2: Resolve enough state to load data labels.
+        // Implicit chart types can fall back to a compatible aggregation when
+        // the explorer default is unavailable for the selected countries.
+        const {
+          queryParams: renderQueryParams,
+          preliminaryState,
+          allLabels,
+          isAsmrType
+        } = await loadInitialChartDataForRendering(queryParams)
 
         // Step 3: Now resolve full state with allLabels
         // This applies constraints AND computes effective date ranges
-        const state = resolveChartStateForRendering(queryParams, allLabels)
+        const state = resolveChartStateForRendering(renderQueryParams, allLabels)
 
         // Build explorer URL from request query params (same params, just /explorer instead of /chart.png)
         // Use request origin so short URL matches client (important for visual parity tests)
         // Filter out PNG-specific params (width, height, dm) that don't apply to explorer
         const requestUrl = getRequestURL(event)
         const siteUrl = requestUrl.origin
-        const explorerParams = new URLSearchParams(requestUrl.search)
+        const explorerParams = new URLSearchParams()
+        for (const [key, value] of Object.entries(renderQueryParams)) {
+          if (Array.isArray(value)) {
+            value.forEach(v => explorerParams.append(key, v))
+          } else {
+            explorerParams.set(key, value)
+          }
+        }
         explorerParams.delete('width')
         explorerParams.delete('height')
         explorerParams.delete('dm') // Dark mode is PNG-specific

--- a/server/utils/chartInitialData.test.ts
+++ b/server/utils/chartInitialData.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadInitialChartDataForRendering } from './chartInitialData'
+
+function createLoader() {
+  return {
+    loadMortalityData: vi.fn(),
+    getAllChartLabels: vi.fn()
+  }
+}
+
+describe('loadInitialChartDataForRendering', () => {
+  it('falls back to yearly when the implicit default chart type has no data', async () => {
+    const loader = createLoader()
+    loader.loadMortalityData
+      .mockRejectedValueOnce(new Error('Failed to fetch mortality data from S3: 404 Not Found'))
+      .mockResolvedValueOnce({ all: { AUS: [{ date: '2010' }], SWE: [{ date: '2010' }] } })
+    loader.getAllChartLabels.mockReturnValueOnce(['2010', '2011'])
+
+    const result = await loadInitialChartDataForRendering(
+      { c: 'SWE,AUS', t: 'le', df: '2010/11', dt: '2024/25' },
+      loader
+    )
+
+    expect(loader.loadMortalityData).toHaveBeenCalledTimes(2)
+    expect(loader.loadMortalityData).toHaveBeenNthCalledWith(1, {
+      chartType: 'fluseason',
+      countries: ['SWE', 'AUS'],
+      ageGroups: ['all']
+    })
+    expect(loader.loadMortalityData).toHaveBeenNthCalledWith(2, {
+      chartType: 'yearly',
+      countries: ['SWE', 'AUS'],
+      ageGroups: ['all']
+    })
+    expect(result.queryParams).toEqual({
+      c: 'SWE,AUS',
+      t: 'le',
+      df: '2010/11',
+      dt: '2024/25',
+      ct: 'yearly'
+    })
+    expect(result.preliminaryState.chartType).toBe('yearly')
+    expect(result.allLabels).toEqual(['2010', '2011'])
+  })
+
+  it('does not fall back when chart type is explicit', async () => {
+    const loader = createLoader()
+    const error = new Error('Failed to fetch mortality data from S3: 404 Not Found')
+    loader.loadMortalityData.mockRejectedValueOnce(error)
+
+    await expect(loadInitialChartDataForRendering(
+      { c: 'SWE,AUS', t: 'le', ct: 'fluseason', df: '2010/11', dt: '2024/25' },
+      loader
+    )).rejects.toThrow(error)
+
+    expect(loader.loadMortalityData).toHaveBeenCalledTimes(1)
+    expect(loader.loadMortalityData).toHaveBeenCalledWith({
+      chartType: 'fluseason',
+      countries: ['SWE', 'AUS'],
+      ageGroups: ['all']
+    })
+  })
+
+  it('does not fall back for non-availability errors', async () => {
+    const loader = createLoader()
+    const error = new Error('S3 request timed out')
+    loader.loadMortalityData.mockRejectedValueOnce(error)
+
+    await expect(loadInitialChartDataForRendering(
+      { c: 'SWE,AUS', t: 'le', df: '2010/11', dt: '2024/25' },
+      loader
+    )).rejects.toThrow(error)
+
+    expect(loader.loadMortalityData).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/utils/chartInitialData.ts
+++ b/server/utils/chartInitialData.ts
@@ -1,0 +1,108 @@
+import { dataLoader } from '../services/dataLoader'
+import {
+  resolveChartStateForRendering,
+  type ChartRenderState
+} from '../../app/lib/state/resolution'
+
+type ChartDataLoader = Pick<typeof dataLoader, 'loadMortalityData' | 'getAllChartLabels'>
+
+export interface InitialChartData {
+  queryParams: Record<string, string | string[]>
+  preliminaryState: ChartRenderState
+  allLabels: string[]
+  isAsmrType: boolean
+}
+
+const IMPLICIT_CHART_TYPE_FALLBACKS: Record<string, string[]> = {
+  fluseason: ['yearly'],
+  midyear: ['yearly']
+}
+
+function hasExplicitChartType(queryParams: Record<string, string | string[]>): boolean {
+  return queryParams.ct !== undefined
+}
+
+function getFallbackQueryParams(
+  queryParams: Record<string, string | string[]>,
+  chartType: string
+): Array<Record<string, string | string[]>> {
+  if (hasExplicitChartType(queryParams)) {
+    return []
+  }
+
+  return (IMPLICIT_CHART_TYPE_FALLBACKS[chartType] ?? []).map(fallbackChartType => ({
+    ...queryParams,
+    ct: fallbackChartType
+  }))
+}
+
+function makeNoDataError(preliminaryState: ChartRenderState): Error {
+  const countriesStr = preliminaryState.countries.join(', ')
+  return new Error(
+    `No data available for ${countriesStr} (${preliminaryState.chartType}). `
+    + 'The requested data may not exist or failed to load.'
+  )
+}
+
+function isFallbackEligibleError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('404') || message.includes('No data available')
+}
+
+/**
+ * Resolve enough chart state to load the initial dataset and labels.
+ *
+ * URLs without an explicit chart type inherit the explorer default. Some country
+ * pairs do not have files for that default aggregation, so SSR retries with a
+ * compatible yearly aggregation before treating the request as unrenderable.
+ */
+export async function loadInitialChartDataForRendering(
+  queryParams: Record<string, string | string[]>,
+  loader: ChartDataLoader = dataLoader
+): Promise<InitialChartData> {
+  const attempts: Array<Record<string, string | string[]>> = [queryParams]
+  let lastError: unknown
+
+  for (let i = 0; i < attempts.length; i += 1) {
+    const attemptQueryParams = attempts[i]!
+    const preliminaryState = resolveChartStateForRendering(attemptQueryParams, [])
+
+    try {
+      const rawData = await loader.loadMortalityData({
+        chartType: preliminaryState.chartType,
+        countries: preliminaryState.countries,
+        ageGroups: preliminaryState.ageGroups
+      })
+
+      const isAsmrType = preliminaryState.type.startsWith('asmr')
+      const allLabels = loader.getAllChartLabels(
+        rawData,
+        isAsmrType,
+        preliminaryState.ageGroups,
+        preliminaryState.countries,
+        preliminaryState.chartType
+      )
+
+      if (allLabels.length === 0) {
+        throw makeNoDataError(preliminaryState)
+      }
+
+      return {
+        queryParams: attemptQueryParams,
+        preliminaryState,
+        allLabels,
+        isAsmrType
+      }
+    } catch (error) {
+      lastError = error
+
+      if (isFallbackEligibleError(error)) {
+        for (const fallbackQueryParams of getFallbackQueryParams(attemptQueryParams, preliminaryState.chartType)) {
+          attempts.push(fallbackQueryParams)
+        }
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError))
+}


### PR DESCRIPTION
## Summary
- add an SSR initial-data helper that retries implicit fluseason/midyear defaults as yearly when the default aggregation is missing
- keep explicit ct values strict, so ct=fluseason still fails if that exact file is unavailable
- include a chart render cache-version bump so old filesystem-cached PNGs are bypassed after deploy

## Verification
- bunx vitest run server/utils/chartInitialData.test.ts
- bun run typecheck
- bun run test
- CI run 27209820568 passed checks and e2e

Note: bun run check cannot start lint in this local shell because the available Node is v20.20.2 while .nvmrc requires 24, and the Bun/ESLint path lacks Object.groupBy. CI Node 22/24 checks passed.