### PR TITLE
Disable the Auto - Tutorial Popup on Both Explorer and Ranking Charts...

### DIFF
--- a/app/pages/explorer.vue
+++ b/app/pages/explorer.vue
@@ -13,7 +13,6 @@ import { useDataAvailability } from '@/composables/useDataAvailability'
 import { useExplorerDataOrchestration } from '@/composables/useExplorerDataOrchestration'
 import { useExplorerColors } from '@/composables/useExplorerColors'
 import { useExplorerChartActions } from '@/composables/useExplorerChartActions'
-import { useTutorial } from '@/composables/useTutorial'
 import { useBrowserNavigation } from '@/composables/useBrowserNavigation'
 import { useUpdateQueue } from '@/composables/useUpdateQueue'
 import type {
@@ -45,9 +44,6 @@ const { goToSignup } = useAuthRedirect()
 // Feature access for tier-gated features
 const { isPro, can } = useFeatureAccess()
 const canAdvancedLE = computed(() => can('ADVANCED_LE'))
-
-// Tutorial for first-time users
-const { autoStartTutorial } = useTutorial()
 
 // Centralized state management with validation
 const state = useExplorerState()
@@ -626,11 +622,6 @@ onMounted(async () => {
     }).catch(() => {
       // Hash computation failed - ignore
     })
-  }
-
-  // Auto-start tutorial for first-time users (skip if skipTutorial query param is present)
-  if (!route.query.skipTutorial) {
-    autoStartTutorial()
   }
 })
 

--- a/app/pages/ranking.vue
+++ b/app/pages/ranking.vue
@@ -49,9 +49,6 @@ definePageMeta({
 const { isAuthenticated } = useAuth()
 const { goToSignup } = useAuthRedirect()
 
-// Tutorial for first-time users
-const { autoStartTutorial } = useTutorial()
-
 // Set page meta (note: ranking page is CSR-only, so OG tags won't be seen by crawlers)
 // Static fallback values are used since dynamic state isn't available during SSR
 const rankingTitle = 'Excess Mortality Ranking'
@@ -343,11 +340,7 @@ const displaySettings = computed(() => ({
 // Only load data on client-side after mount
 onMounted(() => {
   hasLoaded.value = true
-  // Auto-start tutorial for first-time users (skip if skipTutorial query param is present)
   const route = useRoute()
-  if (!route.query.skipTutorial) {
-    autoStartTutorial('ranking')
-  }
 
   // Track this ranking config view (fire-and-forget)
   // This ensures ranking configs show up in "all charts" and track views


### PR DESCRIPTION
## What changed

disable the auto - tutorial popup on both explorer and ranking charts by deafult (? button should still owkr manually)

## Why

This change delivers the requested behavior in a reviewable, verified form.

## Implementation

Updated runtime code to deliver the requested behavior.

## Validation

CI status: success.

## Review and risk

Review completed with no blocking findings.